### PR TITLE
Ability to change date modes in time-series types

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Andrew Martin
+Copyright (c) 2018 - 2024 Andrew Martin
 OSLO Integrator Copyright (c) Microsoft Research
 Amoeba Module Copyright (c) 2014 Mathias Brandewinder
 

--- a/citest.fsx
+++ b/citest.fsx
@@ -4,6 +4,6 @@ open RProvider
 open RProvider.``base``
 open RProvider.zoo
 
-R.c(1.,2.,3)
+R.c (1., 2., 3)
 
-R.as_zoo(R.c(1,2,3))
+R.as_zoo (R.c (1, 2, 3))

--- a/docs/data.fsx
+++ b/docs/data.fsx
@@ -86,7 +86,7 @@ fun modelResults subjectIds hypothesisIds ->
     |> Seq.map (fun (s, h, (a, b)) -> (s, h, a, b))
     |> Bristlecone.Data.ModelSelection.save "/some/dir"
 
-fun (hypothesisResults: ModelSelection.ResultSet.ResultSet<string, Hypotheses.Hypothesis> seq) ->
+fun (hypothesisResults: ModelSelection.ResultSet.ResultSet<string, Hypotheses.Hypothesis<float>,_,_,_> seq) ->
     hypothesisResults
     |> ModelSelection.Akaike.akaikeWeightsForSet (fun h -> h.ReferenceCode)
     |> Bristlecone.Data.ModelSelection.save "/some/dir"

--- a/docs/dendro.fsx
+++ b/docs/dendro.fsx
@@ -51,8 +51,8 @@ location on any day of the year, we can use the `Sunrise.calculate` function.
 
 open Bristlecone.Dendro
 
-let latitude = 54.2
-let longitude = -4.2
+let latitude = 54.2<latitude>
+let longitude = -4.2<longitude>
 
 Sunrise.calculate 2024 04 20 latitude longitude "Europe/London"
 (*** include-it ***)
@@ -61,5 +61,5 @@ Sunrise.calculate 2024 04 20 latitude longitude "Europe/London"
 As an illustration, if we looked at Tromsø in January we would see far less available light:
 *)
 
-Sunrise.calculate 2024 01 10 69.64961 18.95702 "Europe/London"
+Sunrise.calculate 2024 01 10 69.64961<latitude> 18.95702<longitude> "Europe/London"
 (*** include-it ***)

--- a/docs/examples/predator-prey.fsx
+++ b/docs/examples/predator-prey.fsx
@@ -150,7 +150,7 @@ module Graphing =
 
     open Plotly.NET
 
-    let pairedFits (series: Map<string, ModelSystem.FitSeries>) =
+    let pairedFits (series: Map<string, ModelSystem.FitSeries<_,_,_>>) =
         match testResult with
         | Ok r ->
             series
@@ -177,17 +177,17 @@ module Graphing =
                 x
         | Error e -> sprintf "Cannot display data, as model fit did not run successfully (%s)" e
 
-    let pairedFitsForTestResult (testResult: Result<Bristlecone.Test.TestResult, string>) =
+    let pairedFitsForTestResult (testResult: Result<Bristlecone.Test.TestResult<_,_,_>, string>) =
         match testResult with
         | Ok r -> pairedFits r.Series
         | Error e -> sprintf "Cannot display data, as model fit did not run successfully (%s)" e
 
-    let pairedFitsForResult (testResult: Result<Bristlecone.ModelSystem.EstimationResult, string>) =
+    let pairedFitsForResult (testResult: Result<Bristlecone.ModelSystem.EstimationResult<_,_,_>, string>) =
         match testResult with
         | Ok r -> pairedFits (r.Series |> Seq.map (fun kv -> kv.Key.Value, kv.Value) |> Map.ofSeq)
         | Error e -> sprintf "Cannot display data, as model fit did not run successfully (%s)" e
 
-    let parameterTrace (result: Result<ModelSystem.EstimationResult, 'b>) =
+    let parameterTrace (result: Result<ModelSystem.EstimationResult<_,_,_>, 'b>) =
         match result with
         | Ok r ->
             r.Trace
@@ -223,8 +223,8 @@ type PopulationData = FSharp.Data.CsvProvider<"data/lynx-hare.csv", ResolutionFo
 let data =
     let csv = PopulationData.Load(__SOURCE_DIRECTORY__ + "/data/lynx-hare.csv")
 
-    [ (code "hare").Value, Time.TimeSeries.fromObservations (csv.Rows |> Seq.map (fun r -> float r.Hare, r.Year))
-      (code "lynx").Value, Time.TimeSeries.fromObservations (csv.Rows |> Seq.map (fun r -> float r.Lynx, r.Year)) ]
+    [ (code "hare").Value, Time.TimeSeries.fromNeoObservations (csv.Rows |> Seq.map (fun r -> float r.Hare, r.Year))
+      (code "lynx").Value, Time.TimeSeries.fromNeoObservations (csv.Rows |> Seq.map (fun r -> float r.Lynx, r.Year)) ]
     |> Map.ofList
 
 (*** include-value: data ***)

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -68,7 +68,7 @@ let engine =
     Bristlecone.mkContinuous
     |> Bristlecone.withCustomOptimisation (Optimisation.Amoeba.swarm 5 20 Optimisation.Amoeba.Solver.Default)
 
-let testSettings = Bristlecone.Test.TestSettings<float>.Default
+let testSettings = Bristlecone.Test.TestSettings<_,_,_,_>.Default
 let testResult = Bristlecone.testModel engine testSettings hypothesis
 
 (*** include-fsi-output ***)

--- a/docs/integration.fsx
+++ b/docs/integration.fsx
@@ -53,12 +53,12 @@ function to match the `EstimationEngine.Integration` type signature as follows:
 
 open Bristlecone
 
-let myCustomIntegrator: EstimationEngine.Integrate<'data, 'time> =
+let myCustomIntegrator: EstimationEngine.Integrate<'data, 'time, _, _> =
     fun writeOut tInitial tEnd tStep initialConditions externalEnvironment model ->
         invalidOp "Doesn't actually do anything!"
 
-let engine =
-    Bristlecone.mkContinuous |> Bristlecone.withContinuousTime myCustomIntegrator
+
+Bristlecone.mkContinuous |> Bristlecone.withContinuousTime myCustomIntegrator
 
 (**
 

--- a/docs/model-selection.fsx
+++ b/docs/model-selection.fsx
@@ -57,7 +57,7 @@ If you are working with `ResultSet`s, calculating and saving the weights is easi
 be completed as below:
 *)
 
-fun (hypothesisResults: ModelSelection.ResultSet.ResultSet<string, Language.Hypotheses.Hypothesis> seq) ->
+fun (hypothesisResults: ModelSelection.ResultSet.ResultSet<string, Language.Hypotheses.Hypothesis<float>, _, _, _> seq) ->
     hypothesisResults
     |> ModelSelection.Akaike.akaikeWeightsForSet (fun h -> h.ReferenceCode)
     |> Bristlecone.Data.ModelSelection.save "/some/dir"

--- a/docs/optimisation.fsx
+++ b/docs/optimisation.fsx
@@ -43,8 +43,7 @@ let myCustomOptimiser: EstimationEngine.Optimiser<float> =
     EstimationEngine.InDetachedSpace
     <| fun writeOut n domain f -> invalidOp "Doesn't actually do anything!"
 
-let engine =
-    Bristlecone.mkContinuous |> Bristlecone.withCustomOptimisation myCustomOptimiser
+Bristlecone.mkContinuous |> Bristlecone.withCustomOptimisation myCustomOptimiser
 
 (**
 ## Included optimisation methods

--- a/docs/time-series.fsx
+++ b/docs/time-series.fsx
@@ -1,0 +1,78 @@
+(**
+---
+title: Time-Series and Time-Frames
+category: Components
+categoryindex: 4
+index: 1
+---
+
+[![Script]({{root}}/img/badge-script.svg)]({{root}}/{{fsdocs-source-basename}}.fsx)&emsp;
+[![Notebook]({{root}}/img/badge-notebook.svg)]({{root}}/{{fsdocs-source-basename}}.ipynb)
+*)
+
+(*** condition: prepare ***)
+#nowarn "211"
+#r "../src/Bristlecone/bin/Debug/netstandard2.0/Bristlecone.dll"
+(*** condition: fsx ***)
+#if FSX
+#r "nuget: Bristlecone,{{fsdocs-package-version}}"
+#endif // FSX
+(*** condition: ipynb ***)
+#if IPYNB
+#r "nuget: Bristlecone,{{fsdocs-package-version}}"
+#endif // IPYNB
+
+(**
+Time-series and time-frames
+========================
+
+Bristlecone includes core representations of time-series,, time-frames, and
+time indexes. 
+
+A key concept is the date mode. Bristlecone supports using different modes of measuring
+time, from simple `DateTime` representation (calendar time) to various dating methods
+commonly used in long-term ecology and archaeology.
+
+The time-related types are included in the `Bristlecone.Time` module:
+*)
+
+open System
+open Bristlecone
+open Bristlecone.Time
+
+(***
+## Time Series
+
+A time-series is a representation of data ordered in time by the date
+of observation.
+
+### From calendar-date observations
+
+Time-series may be created from date-time observations using built-in .NET
+types and the `TimeSeries.fromNeoObservations` function:
+*)
+
+let someObservations = [
+    2.1, DateTime(2020, 03, 21)
+    5.4, DateTime(2020, 03, 22)
+    -54.2, DateTime(2020, 03, 23)
+]
+
+let ts = TimeSeries.fromNeoObservations someObservations
+(*** include-value: ts ***)
+
+(**
+### From radiocarbon dates
+
+As an example of an alternative date format, uncalibrated radiocarbon dates 
+may be used as follows:
+*)
+
+let someDatedValues = [
+    1654, DatingMethods.Radiocarbon 345<``BP (radiocarbon)``>
+    982, DatingMethods.Radiocarbon -2<``BP (radiocarbon)``>
+    5433, DatingMethods.Radiocarbon 1023<``BP (radiocarbon)``>
+]
+
+let tsRadiocarbon = TimeSeries.fromObservations DateMode.radiocarbonDateMode someDatedValues
+(*** include-value: tsRadiocarbon ***)

--- a/docs/workflow.fsx
+++ b/docs/workflow.fsx
@@ -114,7 +114,7 @@ the orchestration agent:
 let orchestrator =
     Orchestration.OrchestrationAgent(logger, System.Environment.ProcessorCount, false)
 
-fun datasets hypotheses engine ->
+fun datasets hypotheses (engine:EstimationEngine.EstimationEngine<float,System.DateTime,System.TimeSpan,System.TimeSpan>) ->
 
     // Orchestrate the analyses
     let work = workPackages datasets hypotheses engine

--- a/src/Bristlecone.Dendro/Data.fs
+++ b/src/Bristlecone.Dendro/Data.fs
@@ -1,45 +1,57 @@
 namespace Bristlecone.Data
 
-open Bristlecone
-open Bristlecone.Time
-open Bristlecone.Dendro
-
 module PlantIndividual =
 
-    open FSharp.Data
+    open Bristlecone
+    open Bristlecone.Time
+    open Bristlecone.Dendro
+    open Bristlecone.Dendro.Units
 
-    type RingWidthData = CsvProvider<"data-types/ring-width.csv">
-    type EnvironmentVariableData = CsvProvider<"data-types/env-variable.csv">
+    /// Load plant-specific time-series from CSV files.
+    module Csv =
 
-    let loadRingWidths (fileName: string) =
-        let data = RingWidthData.Load fileName
+        open FSharp.Data
 
-        data.Rows
-        |> Seq.groupBy (fun row -> row.``Plant Code``)
-        |> Seq.map (fun (code, rows) ->
-            let growth =
+        type RingWidthData = CsvProvider<"data-types/ring-width.csv">
+        type EnvironmentVariableData = CsvProvider<"data-types/env-variable.csv">
+
+        /// <summary>Load ring widths from a CSV file that contains 'Year', 'Plant Code',
+        /// and 'Increment (mm)' columns.</summary>
+        /// <param name="csvFileName">The file to load</param>
+        /// <returns>A plant individual containing the growth series.</returns>
+        let loadRingWidths (csvFileName: string) =
+            let data = RingWidthData.Load csvFileName
+
+            data.Rows
+            |> Seq.groupBy (fun row -> row.``Plant Code``)
+            |> Seq.map (fun (code, rows) ->
+                let growth =
+                    rows
+                    |> Seq.sortBy (fun i -> i.Year)
+                    |> Seq.map (fun i -> (float i.``Increment (mm)`` * 1.<millimetre/year>, i.Year * 1<year> |> DatingMethods.Annual))
+                    |> TimeSeries.fromObservations DateMode.annualDateMode
+                    |> GrowthSeries.Absolute
+                    |> PlantIndividual.PlantGrowth.RingWidth
+
+                { Identifier = code |> ShortCode.create |> Option.get
+                  Growth = growth
+                  InternalControls = [] |> Map.ofList
+                  Environment = [] |> Map.ofList }
+                : PlantIndividual.PlantIndividual<DatingMethods.Annual,int<year>,int<year>>)
+            |> Seq.toList
+
+        /// <summary>Load plant-specific environmental time-series from
+        /// a CSV file, where all time-series are specified in a single CSV.</summary>
+        /// <param name="fileName">The CSV file to load from.</param>
+        /// <returns>A map of time-series by their plant individual.</returns>
+        let loadPlantSpecificEnvironments (fileName: string) =
+            let data = EnvironmentVariableData.Load fileName
+
+            data.Rows
+            |> Seq.groupBy (fun row -> row.``Plant Code``)
+            |> Seq.map (fun (code, rows) ->
+                code,
                 rows
-                |> Seq.sortBy (fun i -> i.Date)
-                |> Seq.map (fun i -> (float i.``Increment (mm)`` * 1.<mm>, i.Date))
-                |> TimeSeries.fromObservations
-                |> GrowthSeries.Absolute
-                |> PlantIndividual.RingWidth
-
-            { Identifier = code |> ShortCode.create |> Option.get
-              Growth = growth
-              InternalControls = [] |> Map.ofList
-              Environment = [] |> Map.ofList }
-            : PlantIndividual.PlantIndividual)
-        |> Seq.toList
-
-    let loadLocalEnvironmentVariable (fileName: string) =
-        let data = EnvironmentVariableData.Load fileName
-
-        data.Rows
-        |> Seq.groupBy (fun row -> row.``Plant Code``)
-        |> Seq.map (fun (code, rows) ->
-            code,
-            rows
-            |> Seq.map (fun i -> float i.Predictor, i.Date)
-            |> TimeSeries.fromObservations)
-        |> Seq.toList
+                |> Seq.map (fun i -> float i.Predictor, i.Year * 1<year> |> DatingMethods.Annual)
+                |> TimeSeries.fromObservations DateMode.annualDateMode)
+            |> Seq.toList

--- a/src/Bristlecone.Dendro/Data.fs
+++ b/src/Bristlecone.Dendro/Data.fs
@@ -28,7 +28,8 @@ module PlantIndividual =
                 let growth =
                     rows
                     |> Seq.sortBy (fun i -> i.Year)
-                    |> Seq.map (fun i -> (float i.``Increment (mm)`` * 1.<millimetre/year>, i.Year * 1<year> |> DatingMethods.Annual))
+                    |> Seq.map (fun i ->
+                        (float i.``Increment (mm)`` * 1.<millimetre / year>, i.Year * 1<year> |> DatingMethods.Annual))
                     |> TimeSeries.fromObservations DateMode.annualDateMode
                     |> GrowthSeries.Absolute
                     |> PlantIndividual.PlantGrowth.RingWidth
@@ -37,7 +38,7 @@ module PlantIndividual =
                   Growth = growth
                   InternalControls = [] |> Map.ofList
                   Environment = [] |> Map.ofList }
-                : PlantIndividual.PlantIndividual<DatingMethods.Annual,int<year>,int<year>>)
+                : PlantIndividual.PlantIndividual<DatingMethods.Annual, int<year>, int<year>>)
             |> Seq.toList
 
         /// <summary>Load plant-specific environmental time-series from

--- a/src/Bristlecone.Dendro/Library.fs
+++ b/src/Bristlecone.Dendro/Library.fs
@@ -21,12 +21,6 @@ module Bristlecone =
     /// <param name="preTransform"></param>
     /// <param name="estimate"></param>
     /// <returns></returns>
-    let oneStepAheadDendro
-        engine
-        system
-        plant
-        preTransform
-        estimate
-        =
+    let oneStepAheadDendro engine system plant preTransform estimate =
         let predictors = PlantIndividual.toTimeSeries plant
         Bristlecone.oneStepAhead engine system preTransform predictors estimate

--- a/src/Bristlecone.Dendro/Library.fs
+++ b/src/Bristlecone.Dendro/Library.fs
@@ -5,27 +5,14 @@ open Bristlecone.Dendro
 
 module Bristlecone =
 
-    /// <summary>Lower time-series data from a plant individual type into
-    /// basic time-series that may be used for model-fitting</summary>
-    /// <param name="plant">A plant individual</param>
-    /// <returns>A coded map of time-series data for model-fitting</returns>
-    let fromDendro (plant: PlantIndividual.PlantIndividual) =
-        let g =
-            match plant.Growth |> PlantIndividual.growthSeries with
-            | GrowthSeries.Absolute g -> g
-            | GrowthSeries.Cumulative g -> g
-            | GrowthSeries.Relative g -> g
-
-        plant.Environment |> Map.add (ShortCode.create "x" |> Option.get) g
-
     /// <summary>Fit a model to plant growth time-series. The plant individual's growth data is always labelled as `x`.</summary>
     /// <param name="engine">A configured estimation engine</param>
     /// <param name="endCondition">The end condition to apply to optimisation</param>
     /// <param name="system">The compiled model system for analysis</param>
     /// <param name="plant">A plant individual</param>
     /// <returns>An estimation result for the given plant, model and fitting method (engine)</returns>
-    let fitDendro engine endCondition system (plant: PlantIndividual.PlantIndividual) =
-        Bristlecone.fit engine endCondition (fromDendro plant) system
+    let fitDendro engine endCondition system plant =
+        Bristlecone.fit engine endCondition (PlantIndividual.toTimeSeries plant) system
 
     /// <summary> Perform n-step-ahead computation on the hypothesis and plant. The plant individual's growth data is always labelled as `x`.</summary>
     /// <param name="engine"></param>
@@ -35,11 +22,11 @@ module Bristlecone =
     /// <param name="estimate"></param>
     /// <returns></returns>
     let oneStepAheadDendro
-        (engine: EstimationEngine.EstimationEngine<float, float>)
+        engine
         system
-        (plant: PlantIndividual.PlantIndividual)
+        plant
         preTransform
         estimate
         =
-        let predictors = fromDendro plant
+        let predictors = PlantIndividual.toTimeSeries plant
         Bristlecone.oneStepAhead engine system preTransform predictors estimate

--- a/src/Bristlecone.Dendro/Plant.fs
+++ b/src/Bristlecone.Dendro/Plant.fs
@@ -10,10 +10,10 @@ module Units =
     [<Measure>]
     type millimetre
 
-    let mmPerMetre : float<millimetre/metre> = 1000.0<millimetre/metre>
+    let mmPerMetre: float<millimetre / metre> = 1000.0<millimetre / metre>
 
 
-// Environmental space contains 
+// Environmental space contains
 
 [<RequireQualifiedAccess>]
 module PlantIndividual =
@@ -24,9 +24,9 @@ module PlantIndividual =
 
         /// Represents a measurement of plant growth.
         type PlantGrowthMeasure<'date, 'timeunit, 'timespan> =
-            | RingWidth of GrowthSeries.GrowthSeries<millimetre,year,'date,'timeunit,'timespan>
-            | BasalArea of GrowthSeries.GrowthSeries<millimetre^2,year,'date,'timeunit,'timespan>
-            | StemVolume of GrowthSeries.GrowthSeries<millimetre^3,year,'date,'timeunit,'timespan>
+            | RingWidth of GrowthSeries.GrowthSeries<millimetre, year, 'date, 'timeunit, 'timespan>
+            | BasalArea of GrowthSeries.GrowthSeries<millimetre^2, year, 'date, 'timeunit, 'timespan>
+            | StemVolume of GrowthSeries.GrowthSeries<millimetre^3, year, 'date, 'timeunit, 'timespan>
 
         /// Get dates in the growth series
         let internal dates growth =
@@ -80,14 +80,24 @@ module PlantIndividual =
         match plant with
         | PlantGrowth.RingWidth rw ->
             match rw with
-            | GrowthSeries.Absolute rws -> rws |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x) |> GrowthSeries.Absolute
-            | GrowthSeries.Cumulative m -> m |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x) |> GrowthSeries.Cumulative
-            | GrowthSeries.Relative rws -> rws |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x) |> GrowthSeries.Relative
+            | GrowthSeries.Absolute rws ->
+                rws
+                |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x)
+                |> GrowthSeries.Absolute
+            | GrowthSeries.Cumulative m ->
+                m
+                |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x)
+                |> GrowthSeries.Cumulative
+            | GrowthSeries.Relative rws ->
+                rws
+                |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x)
+                |> GrowthSeries.Relative
         | _ -> invalidOp "Not implemented"
 
     let bound plant =
         let growthDates = plant.Growth |> PlantGrowth.dates
         let envSeries = plant.Environment |> Map.toList |> List.map snd
+
         let startDates, endDates =
             envSeries
             |> List.map (fun s -> (s.StartDate |> snd, TimeSeries.endDate s))
@@ -103,19 +113,16 @@ module PlantIndividual =
                 |> Map.toList
                 |> List.map (fun (x, y) -> x, y |> TimeSeries.bound startDate endDate |> Option.get)
                 |> Map.ofList
-            Growth =
-                plant.Growth
-                |> PlantGrowth.bound startDate endDate
-                |> Option.get
-        }
+            Growth = plant.Growth |> PlantGrowth.bound startDate endDate |> Option.get }
 
     /// <summary>Where a plant has associated environmental data, only keep observations
     /// where growth and environment time-series are present.</summary>
     let commonTimeline plant =
         let growthDates = plant.Growth |> PlantGrowth.dates |> Seq.toList
+
         let commonDates =
-            plant.Environment 
-            |> Map.toList 
+            plant.Environment
+            |> Map.toList
             |> List.map snd
             |> List.collect (TimeSeries.dates >> Seq.toList)
             |> List.append growthDates

--- a/src/Bristlecone.Dendro/Plant.fs
+++ b/src/Bristlecone.Dendro/Plant.fs
@@ -3,41 +3,62 @@ namespace Bristlecone.Dendro
 open Bristlecone
 open Bristlecone.Time
 
-[<RequireQualifiedAccess>]
-module EnvironmentalVariables =
+module Units =
 
-    type RegionalEnvironment = CodedMap<TimeSeries<float>>
-    type LocalEnvironment = CodedMap<TimeSeries<float>>
+    open FSharp.Data.UnitSystems.SI.UnitNames
 
-// Year
-[<Measure>]
-type year
+    [<Measure>]
+    type millimetre
 
-// Millimetre
-[<Measure>]
-type mm
+    let mmPerMetre : float<millimetre/metre> = 1000.0<millimetre/metre>
+
+
+// Environmental space contains 
 
 [<RequireQualifiedAccess>]
 module PlantIndividual =
 
-    type PlantGrowth =
-        | RingWidth of GrowthSeries.GrowthSeries<mm>
-        | BasalArea of GrowthSeries.GrowthSeries<mm^2>
-        | StemVolume of GrowthSeries.GrowthSeries<mm^3>
+    open Units
 
-    type Trait =
-        | Static of float
-        | Variable of TimeSeries<float>
+    module PlantGrowth =
 
-    type PlantIndividual =
+        /// Represents a measurement of plant growth.
+        type PlantGrowthMeasure<'date, 'timeunit, 'timespan> =
+            | RingWidth of GrowthSeries.GrowthSeries<millimetre,year,'date,'timeunit,'timespan>
+            | BasalArea of GrowthSeries.GrowthSeries<millimetre^2,year,'date,'timeunit,'timespan>
+            | StemVolume of GrowthSeries.GrowthSeries<millimetre^3,year,'date,'timeunit,'timespan>
+
+        /// Get dates in the growth series
+        let internal dates growth =
+            match growth with
+            | RingWidth rw -> GrowthSeries.dates rw
+            | BasalArea a -> GrowthSeries.dates a
+            | StemVolume vol -> GrowthSeries.dates vol
+
+        let internal bound startDate endDate growth =
+            match growth with
+            | RingWidth rw -> rw |> GrowthSeries.bound startDate endDate |> Option.map RingWidth
+            | BasalArea a -> GrowthSeries.bound startDate endDate a |> Option.map BasalArea
+            | StemVolume vol -> GrowthSeries.bound startDate endDate vol |> Option.map StemVolume
+
+
+
+    type Trait<'date, 'timeunit, 'timespan> =
+        | StaticInTime of float
+        | VariableInTime of TimeSeries<float, 'date, 'timeunit, 'timespan>
+
+    /// <summary>A representation of a plant individual and
+    /// the environmental conditions local to it.</summary>
+    type PlantIndividual<'date, 'timeunit, 'timespan> =
         { Identifier: ShortCode.ShortCode
-          Growth: PlantGrowth
-          InternalControls: Map<ShortCode.ShortCode, Trait>
-          Environment: EnvironmentalVariables.LocalEnvironment }
+          Growth: PlantGrowth.PlantGrowthMeasure<'date, 'timeunit, 'timespan>
+          InternalControls: CodedMap<Trait<'date, 'timeunit, 'timespan>>
+          Environment: CodedMap<TimeSeries<float, 'date, 'timeunit, 'timespan>> }
 
-    let removeUnit (x: float<_>) = float x
 
-    let zipEnv envName envData (plant: PlantIndividual) =
+    /// <summary>Attach an environmental time-series to a plant individual,
+    /// for example for a local environmental condition or resource.</summary>
+    let zipEnvironment envName envData plant =
         let code = ShortCode.create envName
 
         match code with
@@ -46,73 +67,34 @@ module PlantIndividual =
             { plant with
                 Environment = plant.Environment.Add(c, envData) }
 
-    /// Assigns local environmental conditions to each plant in a sequence,
+    /// <summary>Assigns local environmental conditions to each plant in a sequence,
     /// given a sequence of environmental time-series where each time-series
-    /// has the code of the plant associated with it.
-    let zipEnvMany envName (env: (string * TimeSeries.TimeSeries<float>) seq) plants =
+    /// has the code of the plant associated with it.</summary>
+    let zipEnvironments envName env plants =
         plants
         |> Seq.map (fun s -> (s.Identifier.Value, s))
         |> Seq.keyMatch env
-        |> Seq.map (fun (_, plant, e) -> zipEnv envName plant e)
+        |> Seq.map (fun (_, plant, e) -> zipEnvironment envName plant e)
 
     let growthSeries plant =
         match plant with
-        | RingWidth rw ->
+        | PlantGrowth.RingWidth rw ->
             match rw with
-            | GrowthSeries.Absolute rws -> rws |> TimeSeries.map (fun (x, t) -> removeUnit x) |> GrowthSeries.Absolute
-            | GrowthSeries.Cumulative m -> m |> TimeSeries.map (fun (x, t) -> removeUnit x) |> GrowthSeries.Cumulative
-            | GrowthSeries.Relative rws -> rws |> TimeSeries.map (fun (x, t) -> removeUnit x) |> GrowthSeries.Relative
+            | GrowthSeries.Absolute rws -> rws |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x) |> GrowthSeries.Absolute
+            | GrowthSeries.Cumulative m -> m |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x) |> GrowthSeries.Cumulative
+            | GrowthSeries.Relative rws -> rws |> TimeSeries.map (fun (x, t) -> removeUnitFromFloat x) |> GrowthSeries.Relative
         | _ -> invalidOp "Not implemented"
 
-    let private toCumulativeGrowth' (growth: GrowthSeries.GrowthSeries<_>) =
-        match growth with
-        | GrowthSeries.Absolute g ->
-            let time = g |> TimeSeries.toObservations |> Seq.map snd
-            let agr = g |> TimeSeries.toObservations |> Seq.map fst
-            let biomass = agr |> Seq.scan (+) 0.<_> |> Seq.tail |> Seq.toList
-            TimeSeries.fromObservations (Seq.zip biomass time) |> GrowthSeries.Cumulative
-        | GrowthSeries.Relative _ -> failwith "Not implemented"
-        | GrowthSeries.Cumulative _ -> growth
-
-    let private toRelativeGrowth' (growth: GrowthSeries.GrowthSeries<_>) =
-        match growth with
-        | GrowthSeries.Absolute g ->
-            let time = g |> TimeSeries.toObservations |> Seq.map snd
-            let agr = g |> TimeSeries.toObservations |> Seq.map fst
-            let biomass = agr |> Seq.scan (+) 0.<_> |> Seq.tail |> Seq.toList
-            let rgr = agr |> Seq.mapi (fun i a -> a / biomass.[i] * 1.<_>)
-            TimeSeries.fromObservations (Seq.zip rgr time) |> GrowthSeries.Relative
-        | GrowthSeries.Relative _ -> growth
-        | GrowthSeries.Cumulative g ->
-            // Calculate agr and divide agr by biomass
-            failwith "Not implemented"
-
-    let toRelativeGrowth (plant: PlantIndividual) =
-        match plant.Growth with
-        | RingWidth s ->
-            { plant with
-                Growth = s |> toRelativeGrowth' |> RingWidth }
-        | _ -> invalidOp "Not implemented"
-
-    let toCumulativeGrowth (plant: PlantIndividual) =
-        match plant.Growth with
-        | RingWidth s ->
-            { plant with
-                Growth = s |> toCumulativeGrowth' |> RingWidth }
-        | _ -> invalidOp "Not implemented"
-
-    let bound (plant: PlantIndividual) =
-        let allSeries =
-            let response = plant.Growth |> growthSeries |> GrowthSeries.growthToTime
-            let envSeries = plant.Environment |> Map.toList |> List.map snd
-            response :: envSeries
-
+    let bound plant =
+        let growthDates = plant.Growth |> PlantGrowth.dates
+        let envSeries = plant.Environment |> Map.toList |> List.map snd
         let startDates, endDates =
-            allSeries
-            |> List.map (fun s -> (s.StartDate, TimeSeries.endDate s))
+            envSeries
+            |> List.map (fun s -> (s.StartDate |> snd, TimeSeries.endDate s))
+            |> List.append [ growthDates |> Seq.head, growthDates |> Seq.last ]
             |> List.unzip
 
-        let startDate = startDates |> List.map snd |> List.max
+        let startDate = startDates |> List.max
         let endDate = endDates |> List.min
 
         { plant with
@@ -123,35 +105,33 @@ module PlantIndividual =
                 |> Map.ofList
             Growth =
                 plant.Growth
-                |> growthSeries
-                |> GrowthSeries.growthToTime
-                |> TimeSeries.bound startDate endDate
+                |> PlantGrowth.bound startDate endDate
                 |> Option.get
-                |> TimeSeries.map (fun (x, t) -> x * 1.<mm>)
-                |> GrowthSeries.Absolute
-                |> RingWidth }
+        }
 
-    /// Where a plant has associated environmental data, discard the beginning
-    /// or end of the growth and environment time-series where not all data
-    /// are present.
-    let keepCommonYears (plant: PlantIndividual) =
-        let allSeries =
-            let response = plant.Growth |> growthSeries |> GrowthSeries.growthToTime
-            let envSeries = plant.Environment |> Map.toList |> List.map snd
-            response :: envSeries
-
+    /// <summary>Where a plant has associated environmental data, only keep observations
+    /// where growth and environment time-series are present.</summary>
+    let commonTimeline plant =
+        let growthDates = plant.Growth |> PlantGrowth.dates |> Seq.toList
         let commonDates =
-            allSeries
+            plant.Environment 
+            |> Map.toList 
+            |> List.map snd
             |> List.collect (TimeSeries.dates >> Seq.toList)
+            |> List.append growthDates
             |> List.groupBy id
-            |> List.where (fun x -> x |> snd |> Seq.length = allSeries.Length)
+            |> List.where (fun x -> x |> snd |> Seq.length = plant.Environment.Count + 1)
             |> List.map fst
-
-        let mapts f = TimeSeries.map f
 
         let makeCommonTime y =
             let common = commonDates |> List.map (fun t -> ((y |> TimeSeries.findExact t)))
-            common |> TimeSeries.fromObservations
+            common |> TimeSeries.fromObservations y.DateMode
+
+        let commonPlant =
+            match plant.Growth with
+            | PlantGrowth.RingWidth rw -> rw |> GrowthSeries.filter commonDates |> PlantGrowth.RingWidth
+            | PlantGrowth.BasalArea b -> b |> GrowthSeries.filter commonDates |> PlantGrowth.BasalArea
+            | PlantGrowth.StemVolume v -> v |> GrowthSeries.filter commonDates |> PlantGrowth.StemVolume
 
         { plant with
             Environment =
@@ -159,11 +139,17 @@ module PlantIndividual =
                 |> Map.toList
                 |> List.map (fun (x, y) -> (x, makeCommonTime y))
                 |> Map.ofList
-            Growth =
-                plant.Growth
-                |> growthSeries
-                |> GrowthSeries.growthToTime
-                |> makeCommonTime
-                |> mapts (fun (x, t) -> x * 1.<mm>)
-                |> GrowthSeries.Absolute
-                |> RingWidth }
+            Growth = commonPlant }
+
+    /// <summary>Lower time-series data from a plant individual type into
+    /// basic time-series that may be used for model-fitting</summary>
+    /// <param name="plant">A plant individual</param>
+    /// <returns>A coded map of time-series data for model-fitting</returns>
+    let toTimeSeries plant =
+        let g =
+            match plant.Growth with
+            | PlantGrowth.RingWidth g -> GrowthSeries.stripUnits g
+            | PlantGrowth.BasalArea g -> GrowthSeries.stripUnits g
+            | PlantGrowth.StemVolume g -> GrowthSeries.stripUnits g
+
+        plant.Environment |> Map.add (ShortCode.create "x" |> Option.get) g

--- a/src/Bristlecone.Dendro/Sunrise.fs
+++ b/src/Bristlecone.Dendro/Sunrise.fs
@@ -3,8 +3,11 @@ namespace Bristlecone.Dendro
 open System
 open Bristlecone.Units
 
-[<Measure>] type latitude
-[<Measure>] type longitude
+[<Measure>]
+type latitude
+
+[<Measure>]
+type longitude
 
 /// <summary>Provides functions for converting to and from dates in the Julian calendar</summary>
 module JulianDate =
@@ -117,19 +120,23 @@ module Sunrise =
 
     let cosHourAngle declinationOfSun (northLatitude: float<latitude>) =
         (sin (radians (-0.83))
-         - (sin (radians (removeUnitFromFloat northLatitude)) * sin (radians (declinationOfSun))))
-        / (cos (radians (removeUnitFromFloat northLatitude)) * cos (radians (declinationOfSun)))
+         - (sin (radians (removeUnitFromFloat northLatitude))
+            * sin (radians (declinationOfSun))))
+        / (cos (radians (removeUnitFromFloat northLatitude))
+           * cos (radians (declinationOfSun)))
 
     let hourAngleSunrise (lat: float<latitude>) d =
         degrees (
             acos (
-                cos (radians (90.833)) / (cos (radians (Bristlecone.Units.removeUnitFromFloat lat)) * cos (radians (d)))
+                cos (radians (90.833))
+                / (cos (radians (Bristlecone.Units.removeUnitFromFloat lat)) * cos (radians (d)))
                 - tan (radians (Bristlecone.Units.removeUnitFromFloat lat)) * tan (radians (d))
             )
         )
 
     let solarNoon (lng: float<longitude>) eot tzoff =
-        (720. - 4. * removeUnitFromFloat lng - eot + tzoff * 60.) / (float JulianDate.minutesInDay)
+        (720. - 4. * removeUnitFromFloat lng - eot + tzoff * 60.)
+        / (float JulianDate.minutesInDay)
 
     let sunrise sn ha =
         sn - ha * 4. / (float JulianDate.minutesInDay)

--- a/src/Bristlecone.Dendro/Sunrise.fs
+++ b/src/Bristlecone.Dendro/Sunrise.fs
@@ -1,6 +1,10 @@
 namespace Bristlecone.Dendro
 
 open System
+open Bristlecone.Units
+
+[<Measure>] type latitude
+[<Measure>] type longitude
 
 /// <summary>Provides functions for converting to and from dates in the Julian calendar</summary>
 module JulianDate =
@@ -111,21 +115,21 @@ module Sunrise =
     let declinationOfSun oc al =
         degrees (asin (sin (radians (oc)) * sin (radians (al))))
 
-    let cosHourAngle declinationOfSun northLatitude =
+    let cosHourAngle declinationOfSun (northLatitude: float<latitude>) =
         (sin (radians (-0.83))
-         - (sin (radians (northLatitude)) * sin (radians (declinationOfSun))))
-        / (cos (radians (northLatitude)) * cos (radians (declinationOfSun)))
+         - (sin (radians (removeUnitFromFloat northLatitude)) * sin (radians (declinationOfSun))))
+        / (cos (radians (removeUnitFromFloat northLatitude)) * cos (radians (declinationOfSun)))
 
-    let hourAngleSunrise lat d =
+    let hourAngleSunrise (lat: float<latitude>) d =
         degrees (
             acos (
-                cos (radians (90.833)) / (cos (radians (lat)) * cos (radians (d)))
-                - tan (radians (lat)) * tan (radians (d))
+                cos (radians (90.833)) / (cos (radians (Bristlecone.Units.removeUnitFromFloat lat)) * cos (radians (d)))
+                - tan (radians (Bristlecone.Units.removeUnitFromFloat lat)) * tan (radians (d))
             )
         )
 
-    let solarNoon lng eot tzoff =
-        (720. - 4. * lng - eot + tzoff * 60.) / (float JulianDate.minutesInDay)
+    let solarNoon (lng: float<longitude>) eot tzoff =
+        (720. - 4. * removeUnitFromFloat lng - eot + tzoff * 60.) / (float JulianDate.minutesInDay)
 
     let sunrise sn ha =
         sn - ha * 4. / (float JulianDate.minutesInDay)
@@ -133,7 +137,7 @@ module Sunrise =
     let sunset sn ha =
         sn + ha * 4. / (float JulianDate.minutesInDay)
 
-    let calculate year month day latitude longitude timeZoneId =
+    let calculate year month day (latitude: float<latitude>) (longitude: float<longitude>) timeZoneId =
 
         let lat = latitude
         let lng = longitude

--- a/src/Bristlecone.Dendro/data-types/env-variable.csv
+++ b/src/Bristlecone.Dendro/data-types/env-variable.csv
@@ -1,3 +1,3 @@
-Date,Plant Code,Predictor,Uncertainty
-1976-01-01,YUSL01A,-2.3,0.1
-1977-01-01,YUSL01A,1.1,0.1
+Year,Plant Code,Predictor
+1976,YUSL01A,-2.3
+1977,YUSL01A,1.1

--- a/src/Bristlecone.Dendro/data-types/ring-width.csv
+++ b/src/Bristlecone.Dendro/data-types/ring-width.csv
@@ -1,3 +1,3 @@
-Date,Plant Code,Increment (mm)
-1976-01-01,YUSL01A,0.43
-1977-01-01,YUSL01A,0.35
+Year,Plant Code,Increment (mm)
+1976,YUSL01A,0.43
+1977,YUSL01A,0.35

--- a/src/Bristlecone/Bristlecone.fsproj
+++ b/src/Bristlecone/Bristlecone.fsproj
@@ -8,9 +8,9 @@
     <Compile Include="Time.fs" />
     <Compile Include="Logging.fs" />
     <Compile Include="Statistics.fs" />
-    <Compile Include="Integration.fs" />
     <Compile Include="Parameter.fs" />
     <Compile Include="EstimationEngine.fs" />
+    <Compile Include="Integration.fs" />
     <Compile Include="Optimisation.fs" />
     <Compile Include="Confidence.fs" />
     <Compile Include="ModelSelection.fs" />
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="../../docs/img/logo.png" Pack="true" PackagePath="/">
-        <PackageCopyToOutput>true</PackageCopyToOutput>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
     </None>
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/Bristlecone/Confidence.fs
+++ b/src/Bristlecone/Confidence.fs
@@ -48,8 +48,11 @@ module ProfileLikelihood =
     open Bristlecone.ModelSystem
     open Bristlecone.Optimisation
 
-    type EstimateFunction<'data, 'time, 'subject> =
-        EstimationEngine<'data, 'time> -> ModelSystem -> 'subject -> EstimationResult
+    type EstimateFunction<'data, 'subject, 'date, 'timeunit, 'timespan> =
+        EstimationEngine<'data, 'date, 'timeunit, 'timespan>
+            -> ModelSystem<'data>
+            -> 'subject
+            -> EstimationResult<'date, 'timeunit, 'timespan>
 
     module CustomOptimisationMethod =
 
@@ -165,7 +168,7 @@ module ProfileLikelihood =
 
     /// The profile likelihood method samples the likelihood space
     /// around the Maximum Likelihood Estimate
-    let profile fit engine subject (hypothesis: ModelSystem) n (result: EstimationResult) =
+    let profile fit engine subject (hypothesis: ModelSystem<'data>) n result =
 
         // 1. Set estimation bounds to the MLE
         let hypothesisMle =

--- a/src/Bristlecone/Data.fs
+++ b/src/Bristlecone/Data.fs
@@ -103,7 +103,7 @@ module Trace =
 
     module internal Row =
 
-        let fromEstimate thinBy subject modelId (result: EstimationResult) : seq<BristleconeTrace.Row> =
+        let fromEstimate thinBy subject modelId result : seq<BristleconeTrace.Row> =
             result.Trace
             |> Seq.rev
             |> Seq.mapi (fun iterationNumber (likelihood, values) ->
@@ -156,7 +156,7 @@ module MLE =
 
     module internal Row =
 
-        let fromResult subject hypothesisId (result: EstimationResult) =
+        let fromResult subject hypothesisId result =
             result.Parameters
             |> Parameter.Pool.toList
             |> Seq.map (fun (name, v) ->
@@ -244,7 +244,7 @@ module Series =
 
     module internal Row =
 
-        let fromResult subject hypothesisId (result: EstimationResult) =
+        let fromResult subject hypothesisId result =
             result.Series
             |> Map.toList
             |> Seq.collect (fun (name, series) ->
@@ -253,7 +253,7 @@ module Series =
                 |> Seq.map (fun (v, t) ->
                     IndividualSeries.Row(subject, hypothesisId, name.Value, t, v.Fit, v.Obs, result.Likelihood)))
 
-        let toSeries (data: IndividualSeries) : CodedMap<FitSeries> =
+        let toSeries (data: IndividualSeries) =
             data.Rows
             |> Seq.groupBy (fun r -> r.Variable)
             |> Seq.choose (fun (g, r) ->

--- a/src/Bristlecone/Data.fs
+++ b/src/Bristlecone/Data.fs
@@ -400,7 +400,7 @@ module NStepAhead =
         hypothesisId
         analysisId
         nSteps
-        (result: CodedMap<FitSeries<System.DateTime,'timeunit,'timespan> * Statistics.NStepStatistics>)
+        (result: CodedMap<FitSeries<System.DateTime, 'timeunit, 'timespan> * Statistics.NStepStatistics>)
         =
         result
         |> Seq.collect (fun r ->
@@ -411,7 +411,12 @@ module NStepAhead =
                 NStepAhead.Row(subjectId, hypothesisId, analysisId, t, fit.Obs, nSteps, fit.Fit)))
 
     let internal toStatCsvRows
-        (results: seq<string * string * CodedMap<ModelSystem.FitSeries<'date,'timeunit,'timespan> * Statistics.NStepStatistics>>)
+        (results:
+            seq<
+                string *
+                string *
+                CodedMap<ModelSystem.FitSeries<'date, 'timeunit, 'timespan> * Statistics.NStepStatistics>
+             >)
         =
         results
         |> Seq.collect (fun (s, h, r) ->

--- a/src/Bristlecone/Data.fs
+++ b/src/Bristlecone/Data.fs
@@ -168,7 +168,7 @@ module MLE =
                  v |> Parameter.getTransformedValue)
                 |> IndividualMLE.Row)
 
-        let toResult (modelSystem: ModelSystem) (data: IndividualMLE) =
+        let toResult (modelSystem: ModelSystem<'data>) (data: IndividualMLE) =
             if data.Rows |> Seq.isEmpty then
                 Error "An MLE file is corrupt"
             else
@@ -207,7 +207,7 @@ module MLE =
     /// <param name="modelId">An identifier for the model that was fit</param>
     /// <returns>A sequence of tuples which contain the analysis ID followed by another tuple
     /// that contains the likelihood and theta (parameter set)</returns>
-    let load directory subject (modelSystem: ModelSystem) modelId =
+    let load directory subject (modelSystem: ModelSystem<'data>) modelId =
         let files = Config.fileMatch directory subject modelId Config.DataType.MLE
 
         files
@@ -260,7 +260,7 @@ module Series =
                 let ts =
                     r
                     |> Seq.map (fun r -> ({ Fit = r.Expected; Obs = r.Observed }, r.Time))
-                    |> TimeSeries.fromObservations
+                    |> TimeSeries.fromObservations DateMode.calendarDateMode
 
                 ShortCode.create g |> Option.map (fun c -> c, ts))
             |> Map.ofSeq
@@ -303,7 +303,7 @@ module EstimationResult =
     /// Load an `EstimationResult` that has previously been saved as
     /// three seperate dataframes. Results will only be reconstructed
     /// when file names and formats are in original Bristlecone format.
-    let loadAll directory subject (modelSystem: ModelSystem) modelId =
+    let loadAll directory subject (modelSystem: ModelSystem<'data>) modelId =
         let mles =
             MLE.load directory subject modelSystem modelId
             |> Seq.map (fun (k, v) -> k.ToString(), v)
@@ -361,7 +361,7 @@ module ModelSelection =
 
     module Row =
 
-        let fromResult (result: seq<string * string * EstimationResult * AkaikeWeight>) =
+        let fromResult (result: seq<string * string * EstimationResult<'data, 'timeunit, 'timespan> * AkaikeWeight>) =
             result
             |> Seq.map (fun (subject, hypothesisId, r, aic) ->
                 (subject, hypothesisId, r.ResultId, aic.Likelihood, aic.AIC, aic.AICc, aic.Weight)
@@ -400,7 +400,7 @@ module NStepAhead =
         hypothesisId
         analysisId
         nSteps
-        (result: CodedMap<FitSeries * Statistics.NStepStatistics>)
+        (result: CodedMap<FitSeries<System.DateTime,'timeunit,'timespan> * Statistics.NStepStatistics>)
         =
         result
         |> Seq.collect (fun r ->
@@ -411,7 +411,7 @@ module NStepAhead =
                 NStepAhead.Row(subjectId, hypothesisId, analysisId, t, fit.Obs, nSteps, fit.Fit)))
 
     let internal toStatCsvRows
-        (results: seq<string * string * CodedMap<ModelSystem.FitSeries * Statistics.NStepStatistics>>)
+        (results: seq<string * string * CodedMap<ModelSystem.FitSeries<'date,'timeunit,'timespan> * Statistics.NStepStatistics>>)
         =
         results
         |> Seq.collect (fun (s, h, r) ->

--- a/src/Bristlecone/Diagnostics.fs
+++ b/src/Bristlecone/Diagnostics.fs
@@ -25,7 +25,12 @@ module Convergence =
     /// <param name="hypothesisId">The hypothesis identifier</param>
     /// <param name="result">A result set (of 1 .. many results) for a particular subject and hypothesis</param>
     /// <returns>If more than one replicate, the R-hat convergence statistic across replicates</returns>
-    let gelmanRubin nMostRecent subjectId hypothesisId (result: ResultSet.ResultSet<'subject, 'hypothesis>) =
+    let gelmanRubin
+        nMostRecent
+        subjectId
+        hypothesisId
+        (result: ResultSet.ResultSet<'subject, 'hypothesis, 'date, 'timeunit, 'timespan>)
+        =
         printfn "Calculating Rhat for %s (H = %s)" subjectId hypothesisId
 
         if result.AllResults |> Seq.isEmpty || result.BestResult.IsNone then
@@ -69,7 +74,12 @@ module Convergence =
     /// <param name="hypothesis">A function to retrieve a hypothesis ID from a hypothesis</param>
     /// <param name="result">A result set (of 1 .. many results) for a particular subject and hypothesis</param>
     /// <returns>If more than one replicate, the R-hat convergence statistic across replicates</returns>
-    let gelmanRubinAll nMostRecent subject hypothesis (results: ResultSet.ResultSet<'subject, 'hypothesis> seq) =
+    let gelmanRubinAll
+        nMostRecent
+        subject
+        hypothesis
+        (results: ResultSet.ResultSet<'subject, 'hypothesis, 'date, 'timeunit, 'timespan> seq)
+        =
         results
         |> Seq.choose (fun r -> gelmanRubin nMostRecent (subject r.Subject) (hypothesis r.Hypothesis) r)
         |> Seq.concat
@@ -127,7 +137,14 @@ module ModelComponents =
     let calculateComponents
         fitFn
         engine
-        (result: ResultSet.ResultSet<'subject, Loggers.IComponentLogger<'data> -> ModelSystem>)
+        (result:
+            ResultSet.ResultSet<
+                'subject,
+                Loggers.IComponentLogger<'data> -> ModelSystem<'data>,
+                'date,
+                'timeunit,
+                'timespan
+             >)
         =
         match result.BestResult with
         | None -> [] |> Map.ofList

--- a/src/Bristlecone/Equations.fs
+++ b/src/Bristlecone/Equations.fs
@@ -22,7 +22,7 @@ module Likelihood =
 
     /// Residual sum of squares. Provides a simple metric of distance between
     /// observed data and model predictions.
-    let sumOfSquares keys : LikelihoodFn<'data> =
+    let sumOfSquares keys : LikelihoodFn<float> =
         fun _ (data: CodedMap<PredictedSeries>) ->
             keys
             |> List.sumBy (fun k ->
@@ -39,7 +39,7 @@ module Likelihood =
     /// Log likelihood function for single equation system, assuming Gaussian error for x.
     /// Requires a parameter 'σ[x]' to be included in any `ModelSystem` that uses it.
     /// </summary>
-    let gaussian key : LikelihoodFn<'data> =
+    let gaussian key : LikelihoodFn<float> =
         fun paramAccessor data ->
             let x = data |> getData key
             let sigmax = paramAccessor.Get "σ[x]"
@@ -63,7 +63,7 @@ module Likelihood =
     /// Log likelihood function for dual simultaneous system, assuming Gaussian error for both x and y.
     /// Requires parameters 'σ[x]', 'σ[y]' and 'ρ' to be included in any `ModelSystem` that uses it.
     /// </summary>
-    let bivariateGaussian key1 key2 : LikelihoodFn<'data> =
+    let bivariateGaussian key1 key2 : LikelihoodFn<float> =
         fun paramAccessor data ->
             let x = data |> getData key1
             let y = data |> getData key2

--- a/src/Bristlecone/Equations.fs
+++ b/src/Bristlecone/Equations.fs
@@ -22,7 +22,7 @@ module Likelihood =
 
     /// Residual sum of squares. Provides a simple metric of distance between
     /// observed data and model predictions.
-    let sumOfSquares keys : LikelihoodFn =
+    let sumOfSquares keys : LikelihoodFn<'data> =
         fun _ (data: CodedMap<PredictedSeries>) ->
             keys
             |> List.sumBy (fun k ->
@@ -39,7 +39,7 @@ module Likelihood =
     /// Log likelihood function for single equation system, assuming Gaussian error for x.
     /// Requires a parameter 'σ[x]' to be included in any `ModelSystem` that uses it.
     /// </summary>
-    let gaussian key : LikelihoodFn =
+    let gaussian key : LikelihoodFn<'data> =
         fun paramAccessor data ->
             let x = data |> getData key
             let sigmax = paramAccessor.Get "σ[x]"
@@ -63,7 +63,7 @@ module Likelihood =
     /// Log likelihood function for dual simultaneous system, assuming Gaussian error for both x and y.
     /// Requires parameters 'σ[x]', 'σ[y]' and 'ρ' to be included in any `ModelSystem` that uses it.
     /// </summary>
-    let bivariateGaussian key1 key2 : LikelihoodFn =
+    let bivariateGaussian key1 key2 : LikelihoodFn<'data> =
         fun paramAccessor data ->
             let x = data |> getData key1
             let y = data |> getData key2

--- a/src/Bristlecone/EstimationEngine.fs
+++ b/src/Bristlecone/EstimationEngine.fs
@@ -74,7 +74,7 @@ module EstimationEngine =
 
     type State = float
 
-    type ODE = float<``time index``> -> State -> Environment -> State
+    type ODE = float<``time index``> -> State -> ModelSystem.Environment<State> -> State
 
     type WriteOut = LogEvent -> unit
 

--- a/src/Bristlecone/EstimationEngine.fs
+++ b/src/Bristlecone/EstimationEngine.fs
@@ -6,18 +6,23 @@ open Bristlecone.Time
 /// its likelihood as as objective function that may be optimised.
 module ModelSystem =
 
-    // Models
-    type Response = float
-    type Environment = CodedMap<float>
-    type Time = float
+    type Environment<'data> = CodedMap<'data>
+
+    // Time is defined as either:
+    // - Integration / internal model timesteps
+    // - External ('real') time (radiocarbon, date-time etc.)
+    // Here, we will define time as a float
+    type ModelTime = float<``time index``>
 
     /// An ordinary differential equation that may require fixed or free parameters,
     /// the current time t, the current response value, and / or external environmental time series.
-    type ModelEquation = Parameter.Pool -> Time -> Response -> Environment -> float
+    type ModelEquation<'data> = Parameter.Pool -> ModelTime -> 'data -> Environment<'data> -> 'data
 
     /// Paired time-series representing the true and modelled time-series.
     type PredictedSeries =
         { Expected: float[]; Observed: float[] }
+    // type PredictedSeries<'data,'date,'timeunit,'timespan> =
+    //     TimeSeries.TimeSeries<ModelFitToPoint<'data>, 'date, 'timeunit, 'timespan>
 
     /// A function that returns a parameter's current value by its name.
     type ParameterValueAccessor =
@@ -27,27 +32,27 @@ module ModelSystem =
             let (ParameterValueAccessor v) = this in v name
 
     /// A function that computes the likelihood of a set of parameters.
-    type LikelihoodFn = ParameterValueAccessor -> CodedMap<PredictedSeries> -> float
+    type LikelihoodFn<'data> = ParameterValueAccessor -> CodedMap<PredictedSeries> -> 'data
 
     /// A function that computes a measured system property given a
     /// current (time t) and previous (time t-1) system state.
-    type MeasureEquation = float -> Environment -> Environment -> float
+    type Measurement<'data> = 'data -> Environment<'data> -> Environment<'data> -> 'data
 
-    type ModelSystem =
+    type ModelSystem<'data> =
         { Parameters: Parameter.Pool
-          Equations: CodedMap<ModelEquation>
-          Measures: CodedMap<MeasureEquation>
-          NegLogLikelihood: LikelihoodFn }
+          Equations: CodedMap<ModelEquation<'data>>
+          Measures: CodedMap<Measurement<'data>>
+          NegLogLikelihood: LikelihoodFn<'data> }
 
     type FitValue = { Fit: float; Obs: float }
-    type FitSeries = TimeSeries<FitValue>
+    type FitSeries<'date, 'timeunit, 'timespan> = TimeSeries<FitValue, 'date, 'timeunit, 'timespan>
 
     /// An estimated model fit for a time-series model.
-    type EstimationResult =
+    type EstimationResult<'date, 'timeunit, 'timespan> =
         { ResultId: System.Guid
           Likelihood: float
           Parameters: Parameter.Pool
-          Series: CodedMap<FitSeries>
+          Series: CodedMap<FitSeries<'date, 'timeunit, 'timespan>>
           Trace: (float * float[]) list
           InternalDynamics: CodedMap<float[]> option }
 
@@ -67,19 +72,19 @@ module EstimationEngine =
     type EndCondition<'a> = (Solution<'a>) list -> int -> bool
     type Domain = (float * float * Parameter.Constraint)[]
 
-    type Time = float
     type State = float
-    type ODE = Time -> State -> Environment -> State
+
+    type ODE = float<``time index``> -> State -> Environment -> State
 
     type WriteOut = LogEvent -> unit
 
-    type Integrate<'data, 'time> =
+    type Integrate<'data, 'date, 'timeunit, 'timespan> =
         WriteOut
-            -> 'time
-            -> 'time
-            -> 'time
+            -> float<``time index``>
+            -> float<``time index``>
+            -> float<``time index``>
             -> CodedMap<'data>
-            -> CodedMap<TimeIndex.TimeIndex<'data>>
+            -> CodedMap<TimeIndex.TimeIndex<'data, 'date, 'timeunit, 'timespan>>
             -> CodedMap<ODE>
             -> CodedMap<'data[]>
 
@@ -100,12 +105,12 @@ module EstimationEngine =
         | InTransformedSpace of Optimise<'data>
         | InDetachedSpace of Optimise<'data>
 
-    type TimeMode<'data, 'time> =
+    type TimeMode<'data, 'date, 'timeunit, 'timespan> =
         | Discrete
-        | Continuous of Integrate<'data, 'time>
+        | Continuous of Integrate<'data, 'date, 'timeunit, 'timespan>
 
-    type EstimationEngine<'data, 'time> =
-        { TimeHandling: TimeMode<'data, 'time>
+    type EstimationEngine<'data, 'date, 'timeunit, 'timespan> =
+        { TimeHandling: TimeMode<'data, 'date, 'timeunit, 'timespan>
           OptimiseWith: Optimiser<'data>
           Conditioning: Conditioning<'data>
           LogTo: WriteOut

--- a/src/Bristlecone/Integration.fs
+++ b/src/Bristlecone/Integration.fs
@@ -4,15 +4,16 @@ namespace Bristlecone.Integration
 /// routine into a form that can be used within Bristlecone.
 module Base =
 
+    open Bristlecone
     open Bristlecone.Logging
     open Bristlecone.Time
 
     /// Generates a coded map of time-series where all values are NaN.
-    let nanResult tInitial tEnd tStep modelMap =
+    let nanResult tInitial tEnd (tStep: float<``time index``>) modelMap =
         let variableCodes = modelMap |> Map.toArray |> Array.unzip |> fst
 
         let fakeSeries =
-            let count = (tEnd - tInitial + 1.) / tStep |> int
+            let count = (tEnd - tInitial + 1.<``time index``>) / tStep |> int
             [ 1..count ] |> List.map (fun _ -> nan) |> List.toArray
 
         variableCodes |> Array.map (fun k -> (k, fakeSeries)) |> Map.ofArray
@@ -29,9 +30,9 @@ module Base =
             | None -> value)
 
     let applyExternalEnvironment
-        (time: float)
-        (externalEnv: Map<'a, TimeIndex.TimeIndex<'b>>)
-        (currentEnv: Map<'a, 'b>)
+        (time: float<``time index``>)
+        (externalEnv: Map<'a, TimeIndex.TimeIndex<'T, 'date, 'timeunit, 'timespan>>)
+        (currentEnv: Map<'a, 'T>)
         =
         currentEnv
         |> Map.map (fun k v ->
@@ -41,7 +42,16 @@ module Base =
             | Some index -> index.[time]
             | None -> v)
 
-    let solve log integrate tInitial tEnd tStep initialConditions externalEnvironment modelMap : Map<'a, float[]> =
+    let solve
+        log
+        integrate
+        (tInitial: float<``time index``>)
+        tEnd
+        tStep
+        initialConditions
+        externalEnvironment
+        modelMap
+        : Map<'a, float[]> =
 
         // A. Setup initial vector
         let modelKeys, modelEqs = modelMap |> Map.toArray |> Array.unzip
@@ -53,13 +63,13 @@ module Base =
             |> Array.unzip
 
         // B. Setup composite function to integrate
-        let mutable iteration = 1
+        let mutable iteration = 1<iteration>
 
-        let rp (t: float) x =
-            if iteration % 5000 = 0 then
+        let rp t x =
+            if iteration % 5000<iteration> = 0<iteration> then
                 log <| GeneralEvent(sprintf "[Integration] Slow for %f - %A" t x)
 
-            iteration <- iteration + 1
+            iteration <- iteration + 1<iteration>
 
             let environment =
                 if t < tInitial + tStep then
@@ -83,6 +93,8 @@ module Base =
 /// Oslo is an integration library provided by Microsoft Research Cambridge.
 module Oslo =
 
+    open Bristlecone
+    open Bristlecone.Time
     open Microsoft.Research.Oslo
 
     module Options =
@@ -110,16 +122,27 @@ module Oslo =
             )
 
 
-    let integrate' options tInitial tEnd tStep initialVector rp =
+    let integrate'
+        options
+        (tInitial: float<``time index``>)
+        (tEnd: float<``time index``>)
+        (tStep: float<``time index``>)
+        initialVector
+        rp
+        =
         let rk =
             Ode.RK547M(
-                tInitial,
+                tInitial |> Units.removeUnitFromFloat,
                 (initialVector |> Vector),
-                System.Func<double, Vector, Vector>(fun x y -> rp x (y.ToArray()) |> Vector),
+                System.Func<double, Vector, Vector>(fun (x: double) y -> rp x (y.ToArray()) |> Vector),
                 options
             )
 
-        rk.SolveFromToStep(tInitial, tEnd, tStep)
+        rk.SolveFromToStep(
+            tInitial |> Units.removeUnitFromFloat,
+            tEnd |> Units.removeUnitFromFloat,
+            tStep |> Units.removeUnitFromFloat
+        )
         |> Seq.map (fun x -> x.X.ToArray())
         |> Seq.toArray
 

--- a/src/Bristlecone/Integration.fs
+++ b/src/Bristlecone/Integration.fs
@@ -67,6 +67,7 @@ module Base =
 
         let rp (t: float) x =
             let t = t * 1.<``time index``>
+
             if iteration % 5000<iteration> = 0<iteration> then
                 log <| GeneralEvent(sprintf "[Integration] Slow for %f - %A" t x)
 
@@ -173,11 +174,17 @@ module MathNet =
         let f =
             System.Func<float, Vector<float>, Vector<float>>(fun i e -> rp i (e.ToArray()) |> vector)
 
-        RungeKutta.FourthOrder(initialVector |> vector, tInitial |> Units.removeUnitFromFloat, tEnd |> Units.removeUnitFromFloat, n, f)
+        RungeKutta.FourthOrder(
+            initialVector |> vector,
+            tInitial |> Units.removeUnitFromFloat,
+            tEnd |> Units.removeUnitFromFloat,
+            n,
+            f
+        )
         |> Array.map Vector.toArray
 
-    let integrate : EstimationEngine.Integrate<float, 'date, 'timeunit, 'timespan> =
-        fun log tInitial tEnd tStep initialConditions externalEnvironment (modelMap:CodedMap<EstimationEngine.ODE>) ->
+    let integrate: EstimationEngine.Integrate<float, 'date, 'timeunit, 'timespan> =
+        fun log tInitial tEnd tStep initialConditions externalEnvironment (modelMap: CodedMap<EstimationEngine.ODE>) ->
             Base.solve log integrate' tInitial tEnd tStep initialConditions externalEnvironment modelMap
 
 

--- a/src/Bristlecone/Language.fs
+++ b/src/Bristlecone/Language.fs
@@ -359,8 +359,7 @@ module Language =
     /// Terms for designing tests for model systems.
     module Test =
 
-        let defaultSettings =
-            Bristlecone.Test.TestSettings<_,_,_,_>.Default
+        let defaultSettings = Bristlecone.Test.TestSettings<_, _, _, _>.Default
 
         /// If the start value has already been set, it will be overwritten with the new value.
         let withStartValue code value (settings: Bristlecone.Test.TestSettings<float, _, _, _>) =

--- a/src/Bristlecone/Language.fs
+++ b/src/Bristlecone/Language.fs
@@ -236,7 +236,7 @@ module Language =
         type ModelBuilder<'data> = private ModelBuilder of Map<ShortCode.ShortCode, ModelFragment<'data>>
 
         let create: ModelBuilder<float> =
-            Map.empty<ShortCode.ShortCode, ModelFragment<'data>> |> ModelBuilder
+            Map.empty<ShortCode.ShortCode, ModelFragment<float>> |> ModelBuilder
 
         let private unwrap (ModelBuilder m) = m
 
@@ -250,7 +250,7 @@ module Language =
                 | Some c -> map |> Map.add c comp |> ModelBuilder
                 | None -> failwithf "The text '%s' cannot be used to make a short code identifier." name
 
-        let compile builder : ModelSystem.ModelSystem<'data> =
+        let compile builder : ModelSystem.ModelSystem<float> =
             // Ensure only single likelihood function
             // Find all parameters
 
@@ -360,7 +360,7 @@ module Language =
     module Test =
 
         let defaultSettings =
-            Bristlecone.Test.TestSettings<float, 'date, 'dateunit, 'timespan>.Default
+            Bristlecone.Test.TestSettings<_,_,_,_>.Default
 
         /// If the start value has already been set, it will be overwritten with the new value.
         let withStartValue code value (settings: Bristlecone.Test.TestSettings<float, _, _, _>) =
@@ -505,7 +505,7 @@ module Language =
         /// <param name="builder">A builder started with `createFromComponent`</param>
         /// <returns>A list of compiled hypotheses for this model system and specified components.</returns>
         let compile
-            (builder: Writer<ModelBuilder.ModelBuilder<'data>, ComponentName * CodedMap<Parameter.Parameter>> list)
+            (builder: Writer<ModelBuilder.ModelBuilder<float>, ComponentName * CodedMap<Parameter.Parameter>> list)
             =
             if builder |> List.isEmpty then
                 failwith "No hypotheses specified"

--- a/src/Bristlecone/Library.fs
+++ b/src/Bristlecone/Library.fs
@@ -297,7 +297,11 @@ module Bristlecone =
     /// <returns>A test result that indicates the error structure.
     /// It is wrapped in an F# Result, indicating if the procedure
     /// was successful or not.</returns>
-    let tryTestModel engine (settings: Test.TestSettings<float, 'date, 'timeunit, 'timespan>) (model: ModelSystem<float>) =
+    let tryTestModel
+        engine
+        (settings: Test.TestSettings<float, 'date, 'timeunit, 'timespan>)
+        (model: ModelSystem<float>)
+        =
         engine.LogTo <| GeneralEvent "Attempting to generate parameter set."
 
         engine.LogTo
@@ -377,7 +381,13 @@ module Bristlecone =
     /// <param name="model">A model system / hypothesis to fit</param>
     /// <param name="series">Time-series to fit with model</param>
     /// <returns>A list of estimation results (one for each bootstrap) for further analysis</returns>
-    let bootstrap (engine: EstimationEngine.EstimationEngine<float, 'date, 'timeunit, 'timespan>) endCondition bootstrapCount model series =
+    let bootstrap
+        (engine: EstimationEngine.EstimationEngine<float, 'date, 'timeunit, 'timespan>)
+        endCondition
+        bootstrapCount
+        model
+        series
+        =
         let rec bootstrap s numberOfTimes solutions =
             if (numberOfTimes > 0) then
                 let subset = TimeSeries.Bootstrap.removeSingle engine.Random () s // TODO STEPPING
@@ -405,7 +415,9 @@ module Bristlecone =
     let oneStepAhead
         engine
         hypothesis
-        (preTransform: CodedMap<TimeSeries<float, 'date, 'timeunit, 'timespan>> -> CodedMap<TimeSeries<float, 'date, 'timeunit, 'timespan>>)
+        (preTransform:
+            CodedMap<TimeSeries<float, 'date, 'timeunit, 'timespan>>
+                -> CodedMap<TimeSeries<float, 'date, 'timeunit, 'timespan>>)
         (timeSeries)
         (estimatedTheta: Parameter.Pool)
         : CodedMap<FitSeries<'date, 'timeunit, 'timespan> * NStepStatistics> =
@@ -419,7 +431,9 @@ module Bristlecone =
                 fitSeries
                 |> TimeSeries.toObservations
                 |> Seq.pairwise
-                |> Seq.map (fun (t1, t2) -> TimeSeries.fromObservations fitSeries.DateMode [ t1; t2 ] |> TimeSeries.map (fun (x, y) -> x)))
+                |> Seq.map (fun (t1, t2) ->
+                    TimeSeries.fromObservations fitSeries.DateMode [ t1; t2 ]
+                    |> TimeSeries.map (fun (x, y) -> x)))
 
         let dateMode = (timeSeries |> Seq.head).Value.DateMode
 
@@ -461,7 +475,12 @@ module Bristlecone =
         |> Seq.groupBy (fun (k, _, _) -> k)
         |> Seq.map (fun (tsName, values) ->
             let sos = values |> Seq.averageBy (fun (_, x, _) -> (x.Obs - x.Fit) ** 2.)
-            tsName, (values |> Seq.map (fun (_, v, t) -> (v, t)) |> TimeSeries.fromObservations dateMode, { RMSE = sqrt sos }))
+
+            tsName,
+            (values
+             |> Seq.map (fun (_, v, t) -> (v, t))
+             |> TimeSeries.fromObservations dateMode,
+             { RMSE = sqrt sos }))
         |> Map.ofSeq
 
 

--- a/src/Bristlecone/Library.fs
+++ b/src/Bristlecone/Library.fs
@@ -386,11 +386,19 @@ module Bristlecone =
         endCondition
         bootstrapCount
         model
-        series
+        (series: Map<ShortCode.ShortCode,TimeSeries.TimeSeries<float,'date,'timeunit,'timespan>>)
         =
         let rec bootstrap s numberOfTimes solutions =
             if (numberOfTimes > 0) then
-                let subset = TimeSeries.Bootstrap.removeSingle engine.Random () s // TODO STEPPING
+                let resolution =
+                    series 
+                    |> Seq.head
+                    |> fun s -> s.Value |> TimeSeries.resolution
+                let stepping =
+                    match resolution with
+                    | Resolution.Variable -> failwith "Cannot boostrap variable resolution data"
+                    | Resolution.Fixed f -> (series |> Seq.head).Value.DateMode.ResolutionToSpan f
+                let subset = TimeSeries.Bootstrap.removeSingle engine.Random stepping s
                 let result = fit engine endCondition subset model
 
                 engine.LogTo <| GeneralEvent(sprintf "Completed bootstrap %i" numberOfTimes)

--- a/src/Bristlecone/Library.fs
+++ b/src/Bristlecone/Library.fs
@@ -386,18 +386,17 @@ module Bristlecone =
         endCondition
         bootstrapCount
         model
-        (series: Map<ShortCode.ShortCode,TimeSeries.TimeSeries<float,'date,'timeunit,'timespan>>)
+        (series: Map<ShortCode.ShortCode, TimeSeries.TimeSeries<float, 'date, 'timeunit, 'timespan>>)
         =
         let rec bootstrap s numberOfTimes solutions =
             if (numberOfTimes > 0) then
-                let resolution =
-                    series 
-                    |> Seq.head
-                    |> fun s -> s.Value |> TimeSeries.resolution
+                let resolution = series |> Seq.head |> (fun s -> s.Value |> TimeSeries.resolution)
+
                 let stepping =
                     match resolution with
                     | Resolution.Variable -> failwith "Cannot boostrap variable resolution data"
                     | Resolution.Fixed f -> (series |> Seq.head).Value.DateMode.ResolutionToSpan f
+
                 let subset = TimeSeries.Bootstrap.removeSingle engine.Random stepping s
                 let result = fit engine endCondition subset model
 

--- a/src/Bristlecone/ModelSelection.fs
+++ b/src/Bristlecone/ModelSelection.fs
@@ -10,11 +10,11 @@ open Bristlecone.ModelSystem
 module ResultSet =
 
     /// <summary>A representation of all results for a particular subject and hypothesis</summary>
-    type ResultSet<'subject, 'hypothesis> =
+    type ResultSet<'subject, 'hypothesis, 'date, 'timeunit, 'timespan> =
         { Subject: 'subject
           Hypothesis: 'hypothesis
-          BestResult: EstimationResult option
-          AllResults: EstimationResult seq }
+          BestResult: EstimationResult<'date, 'timeunit, 'timespan> option
+          AllResults: EstimationResult<'date, 'timeunit, 'timespan> seq }
 
     /// <summary>Arrange estimation results into subject and hypothesis groups.</summary>
     /// <param name="subjects"></param>
@@ -52,7 +52,11 @@ module ResultSet =
 /// `ResultSet`s. Uses the best MLE for each subject * hypothesis group
 /// an runs `comparisonFn` across these results.</summary>
 /// <returns>The subject, hypothesis code, the original result, and the statistic.</returns>
-let internal comparisonStatistic comparisonFn getRefCode (results: ResultSet.ResultSet<'subject, 'hypothesis> seq) =
+let internal comparisonStatistic
+    comparisonFn
+    getRefCode
+    (results: ResultSet.ResultSet<'subject, 'hypothesis, 'date, 'timeunit, 'timespan> seq)
+    =
     results
     |> Seq.groupBy (fun resultSet -> getRefCode resultSet.Hypothesis)
     |> Seq.collect (fun (_, r) ->
@@ -120,7 +124,7 @@ module Akaike =
     /// <param name="models">The input model results</param>
     /// <returns>An (EstimationResult * float) sequence of estimation results paired to their Akaike weights.</returns>
     /// <exception name="ArgumentException">Occurs when there are no observations within an estimation result.</exception>
-    let akaikeWeights (models: seq<EstimationResult>) =
+    let akaikeWeights (models: seq<EstimationResult<'date, 'timeunit, 'timespan>>) =
         match models |> Seq.tryHead with
         | None -> seq []
         | Some m ->

--- a/src/Bristlecone/Objective.fs
+++ b/src/Bristlecone/Objective.fs
@@ -8,7 +8,7 @@ module Objective =
     open ModelSystem
     open Bristlecone.EstimationEngine
 
-    let parameteriseModel parameterPool point (model: ModelEquation) =
+    let parameteriseModel parameterPool point (model: ModelEquation<'data>) =
         model (point |> Parameter.Pool.fromPointInTransformedSpace parameterPool)
 
     /// Pairs observed time series to predicted series for dynamic variables only.
@@ -30,19 +30,19 @@ module Objective =
                 invalidOp (sprintf "The predicted series %s was a different length to the observed series" key.Value))
 
     /// The system's `Measures` are computed from the product of the solver.
-    let measure (system: ModelSystem) solveDiscrete (expected: CodedMap<float[]>) : CodedMap<float[]> =
+    let measure (system: ModelSystem<'data>) solveDiscrete (expected: CodedMap<float[]>) : CodedMap<float[]> =
         system.Measures
         |> Map.map (fun key measure -> solveDiscrete key measure expected)
         |> Map.fold (fun acc key value -> Map.add key value acc) expected
 
-    let predict (system: ModelSystem) integrate solveDiscrete (p: Point<float>) =
+    let predict (system: ModelSystem<'data>) integrate solveDiscrete (p: Point<float>) =
         system.Equations
         |> Map.map (fun _ v -> parameteriseModel system.Parameters p v)
         |> integrate
         |> measure system solveDiscrete
 
     /// Computes measurement variables and appends to expected data
-    let create (system: ModelSystem) integrate solveDiscrete (observed: CodedMap<float[]>) =
+    let create (system: ModelSystem<'data>) integrate solveDiscrete (observed: CodedMap<float[]>) =
         fun point ->
             point
             |> predict system integrate solveDiscrete

--- a/src/Bristlecone/Optimisation.fs
+++ b/src/Bristlecone/Optimisation.fs
@@ -1382,7 +1382,6 @@ module Amoeba =
 
             let rec search i trace atEnd (a: Amoeba) =
                 if not <| atEnd trace i then
-                    printfn "i %i, val %A" i (trace |> List.tryHead)
                     // writeOut <| OptimisationEvent { Iteration = i; Likelihood = trace; Theta = thetaAccepted }
                     search (i + 1) (a.Best :: trace) atEnd (update a f settings)
                 else

--- a/src/Bristlecone/Solver.fs
+++ b/src/Bristlecone/Solver.fs
@@ -142,10 +142,10 @@ module Solver =
                 <| DebugEvent "No environmental forcing data was supplied. Solving using time points of observations."
 
                 engine.LogTo <| DebugEvent "Solving over time-series with uneven time steps."
-                
+
                 let medianTimespan =
-                    dynamicSeries.Series 
-                    |> Seq.collect(fun ts -> ts.Value.TimeSteps) 
+                    dynamicSeries.Series
+                    |> Seq.collect (fun ts -> ts.Value.TimeSteps)
                     |> Seq.sort
                     |> Seq.splitInto 2
                     |> Seq.skip 1
@@ -153,15 +153,19 @@ module Solver =
                     |> Seq.head
 
                 engine.LogTo
-                <| DebugEvent (sprintf "Setting temporal resolution of solver as the median timestep (%A)." medianTimespan)
+                <| DebugEvent(
+                    sprintf "Setting temporal resolution of solver as the median timestep (%A)." medianTimespan
+                )
 
                 let startDate = (dynamicSeries.Series |> Seq.head).Value.StartDate |> snd
-                let timeIndex = TimeIndex.TimeIndex(
-                    startDate,
-                    Resolution.FixedTemporalResolution.CustomEpoch medianTimespan,
-                    TimeIndex.IndexMode.Exact, // TODO interpolate?
-                    (dynamicSeries.Series |> Seq.head).Value
-                )
+
+                let timeIndex =
+                    TimeIndex.TimeIndex(
+                        startDate,
+                        Resolution.FixedTemporalResolution.CustomEpoch medianTimespan,
+                        TimeIndex.IndexMode.Exact, // TODO interpolate?
+                        (dynamicSeries.Series |> Seq.head).Value
+                    )
 
                 variableExternalStep engine.LogTo engine.TimeHandling timeIndex.Index t0
 

--- a/src/Bristlecone/Statistics.fs
+++ b/src/Bristlecone/Statistics.fs
@@ -26,7 +26,7 @@ module Distributions =
     [<RequireQualifiedAccess>]
     module MutlivariateNormal =
 
-        let mapply (m: Matrix<float>) f =
+        let internal mapply (m: Matrix<float>) f =
             m.EnumerateIndexed() |> Seq.iter (fun struct (i, j, v) -> m.[i, j] <- f v)
             m
 
@@ -63,14 +63,17 @@ module Distributions =
 
 module Interpolate =
 
+    open Bristlecone.Time
+
     /// Interpolates between two data points, for a given time `t`.
-    let bilinear ((t1, v1): float * float) ((t2, v2): float * float) t = v1 + (t - t1) * ((v2 - v1) / (t2 - t1))
+    let bilinear ((t1: float<``time index``>, v1)) ((t2: float<``time index``>, v2)) t =
+        v1 + (t - t1) * ((v2 - v1) / (t2 - t1))
 
     /// Use the previous point
-    let lower ((t1, v1): float * float) ((t2, v2): float * float) t = v1
+    let lower ((t1: float<``time index``>, v1)) ((t2: float<``time index``>, v2)) t = v1
 
     /// Use the next point
-    let upper ((t1, v1): float * float) ((t2, v2): float * float) t = v2
+    let upper ((t1: float<``time index``>, v1)) ((t2: float<``time index``>, v2)) t = v2
 
 
 module Regression =
@@ -93,7 +96,7 @@ module TrendAnalysis =
     open Bristlecone.Time
 
     /// TODO Finish implementation
-    let theilSen (timeDiff: System.TimeSpan -> 'a) (ts: TimeSeries<'a>) =
+    let theilSen (timeDiff: System.TimeSpan -> 'a) (ts: TimeSeries<'a, 'date, 'timeunit, 'timespan>) =
         let allPoints = ts |> TimeSeries.toObservations
 
         let allSlopes =

--- a/src/Bristlecone/Test.fs
+++ b/src/Bristlecone/Test.fs
@@ -97,9 +97,9 @@ module Test =
           RealValue: float
           EstimatedValue: float }
 
-    and TestResult<'timeunit, 'timespan> =
+    and TestResult<'date, 'timeunit, 'timespan> =
         { Parameters: ParameterTestResult list
-          Series: Map<string, FitSeries<float, 'timeunit, 'timespan>>
+          Series: Map<string, FitSeries<'date, 'timeunit, 'timespan>>
           ErrorStructure: Map<string, seq<float>>
           RealLikelihood: float
           EstimatedLikelihood: float }

--- a/src/Bristlecone/Test.fs
+++ b/src/Bristlecone/Test.fs
@@ -151,9 +151,10 @@ module Test =
     let useRandom rnd (settings: TestSettings<_, _, _, _>) = { settings with Random = rnd }
     let useStartTime time settings = { settings with StartDate = time }
 
-    let useDateMode dateMode startDate settings = {
-        settings with StartDate = startDate; DateMode = dateMode
-    }
+    let useDateMode dateMode startDate settings =
+        { settings with
+            StartDate = startDate
+            DateMode = dateMode }
 
     module Compute =
 
@@ -173,7 +174,18 @@ module Test =
                 | Error e -> failwith e)
 
         /// Generate a fixed-resolution time-series for testing model fits
-        let generateFixedSeries writeOut equations timeMode seriesLength startPoint dateMode startDate resolution env theta =
+        let generateFixedSeries
+            writeOut
+            equations
+            timeMode
+            seriesLength
+            startPoint
+            dateMode
+            startDate
+            resolution
+            env
+            theta
+            =
             let applyFakeTime s =
                 TimeSeries.fromSeq dateMode startDate resolution s
 
@@ -182,11 +194,22 @@ module Test =
             match timeMode with
             | Discrete -> invalidOp "Not supported at this time"
             | Continuous i ->
-                i writeOut 0.<``time index``> (seriesLength |> float |> (*) 1.<``time index``>) 1.<``time index``> startPoint env eqs
+                i
+                    writeOut
+                    0.<``time index``>
+                    (seriesLength |> float |> (*) 1.<``time index``>)
+                    1.<``time index``>
+                    startPoint
+                    env
+                    eqs
                 |> Map.map (fun _ v -> applyFakeTime v)
 
         /// A test procedure for computing measures given time series data.
-        let generateMeasures measures startValues (expected: CodedMap<TimeSeries<'T, 'date, 'timeunit, 'timespan>>) : CodedMap<TimeSeries<'T, 'date, 'timeunit, 'timespan>> =
+        let generateMeasures
+            measures
+            startValues
+            (expected: CodedMap<TimeSeries<'T, 'date, 'timeunit, 'timespan>>)
+            : CodedMap<TimeSeries<'T, 'date, 'timeunit, 'timespan>> =
             let time = (expected |> Seq.head).Value |> TimeSeries.toObservations |> Seq.map snd
             let dateMode = (expected |> Seq.head).Value.DateMode
 

--- a/src/Bristlecone/Time.fs
+++ b/src/Bristlecone/Time.fs
@@ -275,6 +275,7 @@ module DateMode =
           ZeroSpan: 'timespan
           TotalDays: 'timespan -> float<day>
           SpanToResolution: 'timespan -> Resolution.FixedTemporalResolution<'timespan>
+          ResolutionToSpan: Resolution.FixedTemporalResolution<'timespan> -> 'timespan
           Divide: 'timespan -> 'timespan -> float
           Minus: 'T -> 'T -> 'timespan }
 
@@ -296,6 +297,7 @@ module DateMode =
           TotalDays = fun ts -> ts.TotalDays * 1.<day>
           SpanToResolution = fun epoch ->
             epoch.Days |> (*) 1<day> |> PositiveInt.create |> Option.get |> Resolution.FixedTemporalResolution.Days
+          ResolutionToSpan = fun res -> failwith "not finished"
           Minus = fun d1 d2 -> d1 - d2
           Divide = fun ts1 ts2 -> float ts1.Ticks / float ts2.Ticks
           SortOldestFirst = fun d1 d2 -> if d1 < d2 then -1 else 1 }
@@ -315,6 +317,7 @@ module DateMode =
                 (years |> Units.removeUnitFromInt |> float |> LanguagePrimitives.FloatWithMeasure)
                 * daysPerYearInOldDates
           SpanToResolution = fun epoch -> oldYearsToResolution epoch
+          ResolutionToSpan = fun res -> failwith "not finished"
           Divide = fun ts1 ts2 -> ts1 / ts2 |> float
           Minus = fun d1 d2 -> d1 - d2 }
 
@@ -443,7 +446,6 @@ module TimeSeries =
         data
         |> Seq.tail // The first time point is used as initial state for the scan
         |> Seq.scan (fun (_, t) v -> (v, t |> TimePoint.increment resolution timeUnitMode)) (data |> Seq.head, t1)
-        // |> fun x -> printfn "intermediate %A" x; x
         |> fromObservations timeUnitMode
 
     /// <summary>Turn a time series into a sequence of observations</summary>

--- a/src/Bristlecone/Time.fs
+++ b/src/Bristlecone/Time.fs
@@ -2,7 +2,30 @@ module Bristlecone.Time
 
 open System
 
-/// Contains F#-friendly extension methods for .NET time types.
+[<Measure>] type day
+[<Measure>] type month
+[<Measure>] type year
+
+// Support the following dating methods:
+[<Measure>] type ``cal yr BP`` // calibrated calendar years before present
+[<Measure>] type ``BP (radiocarbon)`` // uncalibrated years before present
+[<Measure>] type CE // common era
+[<Measure>] type BC
+[<Measure>] type AD
+
+[<Measure>] type ``time index``
+
+type TimeDifference = {
+    DayFraction: float<day>
+    MonthFraction: float<month>
+    YearFraction: float<year>
+}
+
+// Unit conversions:
+let internal convertYearsToMonths (x : float<year>) = x * 12.<month/year>
+
+
+/// <summary>Contains F#-friendly extension methods for .NET time types.</summary>
 [<AutoOpen>]
 module TimeExtensions =
 
@@ -14,334 +37,10 @@ module TimeExtensions =
             let d = DateTime(year, month, day)
             DateTime.SpecifyKind(d, DateTimeKind.Utc)
 
-[<RequireQualifiedAccess>]
-module Resolution =
 
-    /// Represents the width of equally-spaced steps in time.
-    type FixedTemporalResolution =
-        | Years of PositiveInt
-        | Months of PositiveInt
-        | Days of PositiveInt
-        | CustomEpoch of RealTimeSpan
-
-    /// Represents the maximum resolution of the time series
-    type TemporalResolution =
-        | Fixed of FixedTemporalResolution
-        | Variable
-
-    /// Increment time by an increment defined as a fixed temporal resolution.
-    let increment res (t: DateTime) =
-        match res with
-        | Years i -> t.AddYears i.Value
-        | Months i -> t.AddMonths i.Value
-        | Days i -> t.AddDays(float i.Value)
-        | CustomEpoch ticks -> t + ticks.Value
-
-
-type FixedTemporalResolution = Resolution.FixedTemporalResolution
-
-[<RequireQualifiedAccess>]
-module TimeSeries =
-
-    /// A raw observation, at a given time
-    type Observation<'T> = 'T * DateTime
-
-    /// Change in value from one timepoint to another.
-    type Epoch<'T> = 'T * TimeSpan
-
-    /// A sequence of data observed at time points.
-    type FloatingTimeSeries<'T> = private TimeSteps of Epoch<'T>[]
-
-    /// A sequence of data observed at time intervals (regular or irregular),
-    /// where the sampling intervals occur following a fixed start observation.
-    type TimeSeries<'T> =
-        private
-        | FixedTimeSeries of Observation<'T> * FloatingTimeSeries<'T>
-
-        member this.StartDate =
-            let startPoint (FixedTimeSeries(s, _)) = s
-            this |> startPoint
-
-
-    let private innerSeries (FixedTimeSeries(s, TimeSteps ts)) = ts
-    let private unwrap (FixedTimeSeries(s, TimeSteps ts)) = (s, ts)
-    let private createFixedSeries start series = (start, series) |> FixedTimeSeries
-
-    /// Arrange existing observations as a bristlecone `TimeSeries`.
-    /// Observations become ordered and indexed by time.
-    let fromObservations (dataset: seq<Observation<'a>>) : TimeSeries<'a> =
-        if dataset |> Seq.length < 2 then
-            invalidArg "dataset" "The data must be at least two elements long"
-
-        let sorted = dataset |> Seq.sortBy snd
-        let baseline = sorted |> Seq.head
-
-        let timePoints =
-            sorted
-            |> Seq.tail // The first time point is used as initial state in the scan
-            |> Seq.scan
-                (fun (v1, d1, ts) (v2, d2) -> (v2, d2, d2 - d1))
-                (baseline |> fst, baseline |> snd, TimeSpan.Zero)
-            |> Seq.tail // The first time point is removed (it forms the baseline instead)
-            |> Seq.map (fun (v, _, ts) -> (v, ts))
-            |> Seq.toArray
-            |> TimeSteps
-
-        FixedTimeSeries(baseline, timePoints)
-
-    /// Create a time series from a sequence of existing data, where each
-    /// observation is equally spaced in time.
-    let fromSeq t1 resolution (data: seq<'a>) =
-        data
-        |> Seq.tail // The first time point is used as initial state for the scan
-        |> Seq.scan (fun (_, t) v -> (v, t |> Resolution.increment resolution)) (data |> Seq.head, t1)
-        |> fromObservations
-
-    /// Turn a time series into a sequence of observations
-    let toObservations series : seq<Observation<'a>> =
-        let baseline, ts = series |> unwrap
-        ts |> Seq.scan (fun (_, lastDate) (v, ts) -> (v, lastDate + ts)) baseline
-
-    /// Map a function to each value in the time series.
-    let map f series =
-        series
-        |> innerSeries
-        |> Array.map (fun (v, ts) -> (f (v, ts), ts))
-        |> TimeSteps
-        |> createFixedSeries (f (series.StartDate |> fst, TimeSpan.Zero), series.StartDate |> snd)
-
-    /// The time intervals - or *epochs* - that form the time series.
-    let epochs series = series |> innerSeries |> Array.map snd
-
-    let checkMoreThanEqualTo n seq =
-        if seq |> Seq.length >= n then Some seq else None
-
-    /// Remove all time points that occur before the desired start date.
-    let trimStart startDate series =
-        let obs = series |> toObservations
-
-        match obs |> Seq.tryFindIndex (fun (_, t) -> t >= startDate) with
-        | Some startIndex ->
-            obs
-            |> Seq.toArray
-            |> Array.splitAt startIndex
-            |> snd
-            |> checkMoreThanEqualTo 2
-            |> Option.map fromObservations
-        | None -> None
-
-    /// Remove all time points that occur after the desired end date.
-    let trimEnd endDate series =
-        series
-        |> toObservations
-        |> Seq.takeWhile (fun (_, t) -> t <= endDate)
-        |> checkMoreThanEqualTo 2
-        |> Option.map fromObservations
-
-    /// Bound a time series inclusively
-    let bound startDate endDate series =
-        series
-        |> toObservations
-        |> Seq.skipWhile (fun (_, t) -> t < startDate)
-        |> Seq.takeWhile (fun (_, t) -> t <= endDate)
-        |> checkMoreThanEqualTo 2
-        |> Option.map fromObservations
-
-    /// Date of the last observation within the time series.
-    let endDate (series: TimeSeries<'a>) =
-        series |> toObservations |> Seq.last |> snd
-
-    /// Time points of sampling within the time series.
-    let dates (series: TimeSeries<'a>) = series |> toObservations |> Seq.map snd
-
-    /// Find an observation by its exact time of occurrence.
-    let findExact time (series: TimeSeries<'a>) =
-        series |> toObservations |> Seq.find (fun (v, t) -> t = time)
-
-    /// Calculates the temporal resolution of a time series
-    let resolution (series: TimeSeries<'a>) =
-        let epochs = series |> epochs
-
-        if epochs |> Seq.distinct |> Seq.length = 1 then // There is a fixed time period.
-            let fixedEpoch = epochs |> Seq.head
-
-            if fixedEpoch = TimeSpan.Zero then
-                failwith "Cannot have a resolution of zero"
-
-            if fixedEpoch.TotalDays % 1. = 0. then
-                Resolution.Fixed
-                <| FixedTemporalResolution.Days(PositiveInt.create (int fixedEpoch.TotalDays) |> Option.get)
-            else
-                Resolution.Fixed
-                <| FixedTemporalResolution.CustomEpoch(RealTimeSpan.create fixedEpoch |> Option.get)
-        else // A variable time interval exists. This could be months, years, or some other unit.
-            let observations = series |> toObservations
-            let startDate = observations |> Seq.head |> snd
-
-            let monthDifferences =
-                observations
-                |> Seq.map snd
-                |> Seq.tail
-                |> Seq.scan
-                    (fun (t1, m) t2 -> (t2, (t2.Year * 12) + t2.Month))
-                    (startDate, (startDate.Year * 12) + startDate.Month)
-                |> Seq.map snd
-                |> Seq.pairwise
-                |> Seq.map (fun (m1, m2) -> m2 - m1)
-
-            if monthDifferences |> Seq.distinct |> Seq.length = 1 then // There is a fixed monthly stepping
-                let fixedMonths = monthDifferences |> Seq.head
-
-                if fixedMonths % 12 = 0 then
-                    Resolution.Fixed
-                    <| FixedTemporalResolution.Years(PositiveInt.create (fixedMonths / 12) |> Option.get)
-                else
-                    Resolution.Fixed
-                    <| FixedTemporalResolution.Months(PositiveInt.create fixedMonths |> Option.get)
-            else // The time series has variable increments not on day or month cycle
-                Resolution.Variable
-
-    /// Reduces the temporal resolution of `series`.
-    /// The time series must be able to be split exactly into the lower resolution. For example,
-    /// when upscaling from one to three years, the time series must be a multiple of three years.
-    let generalise desiredResolution (upscaleFunction: seq<Observation<'a>> -> 'a) (series: TimeSeries<'a>) =
-        let resolution = series |> resolution
-        let obs = series |> toObservations
-
-        match resolution with
-        | Resolution.Variable -> invalidArg "desiredResolution" "Cannot generalise a variable-resolution time series"
-        | Resolution.Fixed res ->
-            match res with
-            | FixedTemporalResolution.Years oldYears ->
-                match desiredResolution with
-                | FixedTemporalResolution.Years newYears ->
-                    if
-                        newYears > oldYears
-                        && ((float newYears.Value) % (float oldYears.Value) = 0.)
-                        && ((obs |> Seq.length |> float) % (float newYears.Value) = 0.)
-                    then
-                        obs
-                        |> Seq.chunkBySize (newYears.Value / oldYears.Value)
-                        |> Seq.map (fun bin -> (bin |> upscaleFunction, bin |> Seq.head |> snd))
-                        |> fromObservations
-                    else
-                        invalidArg
-                            "desiredResolution"
-                            "The upscaled resolution was not a whole multiple of the old resolution"
-                | _ -> invalidArg "desiredResolution" "Cannot generalise an annual time series to a lower resolution"
-            | FixedTemporalResolution.Days oldDays ->
-                match desiredResolution with
-                | FixedTemporalResolution.Months newMonths ->
-                    obs
-                    |> Seq.groupBy (fun (_, t) -> (t.Year, t.Month))
-                    |> Seq.map (fun ((y, m), g) -> (g |> upscaleFunction, g |> Seq.map snd |> Seq.max))
-                    |> fromObservations
-                | _ -> invalidOp "Not implemented"
-            | _ -> invalidArg "desiredResolution" "Not implemented"
-
-    /// Interpolates missing values in a time series, where missing values
-    /// are represented as an `Option` type.
-    let interpolate (series: TimeSeries<float option>) : TimeSeries<float> =
-        let observations = series |> toObservations |> Seq.toArray
-
-        observations
-        |> Seq.mapi (fun i obs ->
-            match fst obs with
-            | Some _ -> Some(obs, i, i, i)
-            | None ->
-                let lastIndex =
-                    observations |> Seq.take i |> Seq.tryFindIndexBack (fun (o, _) -> o.IsSome)
-
-                let nextIndex =
-                    observations |> Seq.skip i |> Seq.tryFindIndex (fun (o, _) -> o.IsSome)
-
-                if lastIndex.IsSome && nextIndex.IsSome then
-                    Some(obs, i, lastIndex.Value, nextIndex.Value + i)
-                else
-                    None)
-        |> Seq.choose id
-        |> Seq.map (fun (obs, i, last, next) ->
-            if (next - last) = 0 then
-                (observations.[i] |> fst).Value, observations.[i] |> snd
-            else
-                let lastValue = (observations.[last] |> fst).Value
-                let nextValue = (observations.[next] |> fst).Value
-
-                (lastValue
-                 + ((nextValue - lastValue) / (float next - float last)) * (float i - float last)),
-                (obs |> snd))
-        |> fromObservations
-
-    ///**Description**
-    /// Determines if multiple time series have the same temporal extent and time steps.
-    ///**Output Type**
-    ///  * A `TimeSpan [] option` containing the common timeline, or `None` if there is no common timeline.
-    let commonTimeline (series: TimeSeries<'a> list) =
-        let timeSteps = series |> List.map (toObservations >> Seq.map snd >> Seq.toList)
-
-        match timeSteps with
-        | Single
-        | AllIdentical -> Some(series |> List.head |> epochs)
-        | Empty
-        | Neither -> None
-
-    /// Removing a step takes account of leap years.
-    /// NB Never removes the original start point.
-    let bootstrapFixedStep stepping i series =
-        let start, _ = series |> unwrap
-
-        let newData =
-            series
-            |> innerSeries
-            |> Array.map fst
-            |> Array.toList
-            |> List.remove i
-            |> List.toArray
-
-        (List.init (Seq.length newData) (fun _ -> stepping))
-        |> Seq.zip newData
-        |> Seq.toArray
-        |> TimeSteps
-        |> createFixedSeries start
-
-
-    type TimeSeries<'T> with
-        member this.Length = this |> innerSeries |> Array.length
-
-        member this.Head = this |> innerSeries |> Array.head
-
-        member this.TimeSteps = this |> innerSeries |> Array.map snd
-
-        member this.Values = this |> toObservations |> Seq.map fst
-
-        member this.Resolution = this |> resolution
-
-type TimeSeries<'T> = TimeSeries.TimeSeries<'T>
-
-/// Contains functions for bootstrapping time series.
-module Bootstrap =
-
-    /// Randomly remove a single time point from a time-series.
-    let removeSingle (random: System.Random) (data: CodedMap<TimeSeries<float<'v>>>) =
-        let commonTimeSeries =
-            TimeSeries.commonTimeline (data |> Map.toList |> List.map snd)
-
-        match commonTimeSeries with
-        | None -> invalidOp "The time series are not on common time"
-        | Some ts ->
-            match ts.Length with
-            | 0 -> invalidOp "The time series was empty"
-            | _ ->
-                let selection = random.Next(0, ts.Length - 1)
-
-                data
-                |> Map.map (fun _ v -> v |> TimeSeries.bootstrapFixedStep (TimeSpan.FromDays(366.)) selection)
-
-module TimeIndex =
-
-    type IndexMode<'a> =
-        | Interpolate of ((float * 'a) -> (float * 'a) -> float -> 'a)
-        | Exact
+/// <summary>Helper functions for working with
+/// `DateTime` values.</summary>
+module DateTime =
 
     /// Calculates the fractional number of years elapsed between two dates.
     /// The basis used is actual/actual.
@@ -358,10 +57,7 @@ module TimeIndex =
 
         yf2 - yf1 + float wholeYears
 
-    /// Algorithm that ignores leap year days.
-    /// Truncation occurs for 29th Feburary.
-    /// Actual days count basis.
-    let totalYearsElapsed' (d1: DateTime) (d2: DateTime) =
+    let internal totalYearsElapsed' (d1: DateTime) (d2: DateTime) =
         let feb29th = 60
 
         let nonLeapDay (d1: DateTime) =
@@ -396,54 +92,549 @@ module TimeIndex =
 
         float wholeYears + yearFraction
 
+    /// <summary>Calculates the years elapsed between two dates, from
+    /// the earlier to the later date. The algorithm ignores leap year days
+    /// (truncation occurs for the 29th Feburary).</summary>
+    /// <param name="d1">The first date</param>
+    /// <param name="d2">The second date</param>
+    /// <returns>The fraction of years elapsed between the two dates</returns>
     let totalYearsElapsed d1 d2 =
         if d2 > d1 then
-            totalYearsElapsed' d1 d2
+            totalYearsElapsed' d1 d2 * 1.<year>
         else
-            totalYearsElapsed' d2 d1
+            totalYearsElapsed' d2 d1 * 1.<year>
 
     // TODO Take account of day of month. Currently does not handle varying month lengths
-    let totalMonthsElapsed (d1: DateTime) (d2: DateTime) : float =
-        (d2.Month - d1.Month) + (d2.Year - d1.Year) * 12 |> float
+    /// <summary>Calculates the fractional number of total 
+    /// months elapsed between two dates.</summary>
+    /// <param name="d1">The first date</param>
+    /// <param name="d2">The second date</param>
+    /// <returns>The fraction of years elapsed between the two dates</returns>
+    let totalMonthsElapsed (d1: DateTime) (d2: DateTime) =
+        (d2.Month - d1.Month) + (d2.Year - d1.Year) * 12 |> float |> (*) 1.<month>
+
+    let fractionalDifference d1 d2 = {
+        YearFraction = totalYearsElapsed d1 d2
+        MonthFraction = totalMonthsElapsed d1 d2
+        DayFraction = (d2 - d1).TotalDays * 1.<day>
+    }
+
+
+[<RequireQualifiedAccess>]
+module Resolution =
+
+    /// Represents the width of equally-spaced steps in time.
+    type FixedTemporalResolution<'timespan> =
+        | Years of PositiveInt.PositiveInt<year>
+        | Months of PositiveInt.PositiveInt<month>
+        | Days of PositiveInt.PositiveInt<day>
+        | CustomEpoch of 'timespan
+
+    /// Represents the maximum resolution of the time series
+    type TemporalResolution<'timespan> =
+        | Fixed of FixedTemporalResolution<'timespan>
+        | Variable
+
+/// Contains types representing common dating methods in
+/// long term data analysis.
+module DatingMethods =
+
+    /// We assume that dates in old date formats are fixed to
+    /// 365 days per year.
+    let daysPerYearInOldDates = 365.<day/year>
+
+    /// <summary>Represents a date made by radiocarbon measurement</summary>
+    type Radiocarbon = Radiocarbon of int<``BP (radiocarbon)``> with
+        static member Unwrap (Radiocarbon bp) = bp
+        static member (-) (e1, e2) =
+            (e1 |> Radiocarbon.Unwrap) - (e2 |> Radiocarbon.Unwrap)
+        static member (+) (e1, e2) =
+            (e1 |> Radiocarbon.Unwrap) + e2 |> Radiocarbon
+
+        static member TotalYearsElapsed d1 d2 =
+            if d2 > d1 then Radiocarbon.Unwrap d2 - Radiocarbon.Unwrap d1
+            else Radiocarbon.Unwrap d1 - Radiocarbon.Unwrap d2
+
+        static member FractionalDifference d1 d2 =
+            let yearFraction = Radiocarbon.Unwrap d2 - Radiocarbon.Unwrap d1 |> float |> (*) 1.<year>
+            {
+                YearFraction = yearFraction
+                MonthFraction = convertYearsToMonths yearFraction
+                DayFraction = yearFraction * daysPerYearInOldDates
+            }
+
+
+module DateMode =
+    
+    open DatingMethods
+
+    /// <summary>Represents the configuration for handling the specific
+    /// date type `'T` in a time series.</summary>
+    [<CustomComparison>]
+    type DateMode<'T, 'timeunits, 'timespan> = {
+        Resolution: MaximumResolution<'T>
+        GetYear: 'T -> 'timeunits
+        AddYears : 'T -> 'timeunits -> 'T
+        AddMonths : 'T -> int<month> -> 'T
+        AddDays : 'T -> int<day> -> 'T
+        AddTime : 'T -> 'timespan -> 'T
+        Difference : 'T -> 'T -> TimeDifference
+        SortBackwards: bool
+        ZeroSpan: 'timespan
+        TotalDays: 'timespan -> float<day>
+    }
+    with
+        interface IComparable<DateMode<'T, 'timeunits, 'timespan>> with
+            member this.CompareTo other =
+                if this.SortBackwards
+                then (other :> IComparable<_>).CompareTo this
+                else (this :> IComparable<_>).CompareTo other
+
+    /// <summary>Represents the maximum resolution possible
+    /// given a date type representation.</summary>
+    and MaximumResolution<'T> =
+        | Ticks of days:('T -> int<day>) * months:('T -> int<month>)
+        | Year
+
+    let calendarDateMode : DateMode<DateTime, int, TimeSpan> = {
+        Resolution = Ticks((fun d -> d.Day * 1<day>), (fun d -> d.Month * 1<month>))
+        GetYear = fun d -> d.Year
+        AddYears = fun d years -> d.AddYears years
+        AddMonths = fun d months -> months |> Units.removeUnitFromInt |> d.AddMonths
+        AddDays = fun d days -> days |> Units.removeUnitFromInt |> d.AddDays
+        AddTime = fun d timeSpan -> d + timeSpan
+        Difference = DateTime.fractionalDifference
+        SortBackwards = false
+        ZeroSpan = TimeSpan.Zero
+        TotalDays = fun ts -> ts.TotalDays * 1.<day>
+    }
+
+    let radiocarbonDateMode : DateMode<Radiocarbon, int<``BP (radiocarbon)``>, int<``BP (radiocarbon)``>> = {
+        Resolution = Year
+        GetYear = fun d -> d |> Radiocarbon.Unwrap
+        AddYears = fun d years -> d + years
+        AddMonths = fun d months -> d
+        AddDays = fun d days -> d
+        AddTime = fun d timeSpan -> d + timeSpan
+        Difference = fun d1 d2 -> Radiocarbon.FractionalDifference d1 d2
+        SortBackwards = true
+        ZeroSpan = 0<``BP (radiocarbon)``>
+        TotalDays = fun ts -> (ts |> Units.removeUnitFromInt |> float |> LanguagePrimitives.FloatWithMeasure) * daysPerYearInOldDates
+    }
+
+module TimePoint =
+
+    /// Increment time by an increment defined as a fixed temporal resolution.
+    let increment<'date, 'timespan> res (mode: DateMode.DateMode<'date,_,'timespan>) (date:'date) =
+        match res with
+        | Resolution.Years i -> mode.AddYears date i.Value
+        | Resolution.Months i -> mode.AddMonths date i.Value
+        | Resolution.Days i -> mode.AddDays date i.Value
+        | Resolution.CustomEpoch ticks -> mode.AddTime date ticks
+
+
+[<RequireQualifiedAccess>]
+module TimeSeries =
+
+    /// A raw observation, at a given time
+    type Observation<'T, 'date> = 'T * 'date
+
+    /// Change in value from one timepoint to another.
+    type Epoch<'T, 'timespan> = 'T * 'timespan
+
+    /// A sequence of data observed at time points.
+    type FloatingTimeSeries<'T, 'timespan> = private TimeSteps of Epoch<'T, 'timespan>[]
+
+    /// A sequence of data observed at time intervals (regular or irregular),
+    /// where the sampling intervals occur following a fixed start observation.
+    type TimeSeries<'T, 'date, 'timeunit, 'timespan> = //when 'date : (member TimeUnitProperties : TimeUnitProperties<'timespan>)> =
+        private
+        | FixedTimeSeries of DateMode.DateMode<DatingMethods.Radiocarbon, 'timeunit, int<``BP (radiocarbon)``>> * Observation<'T, DatingMethods.Radiocarbon> * FloatingTimeSeries<'T, int<``BP (radiocarbon)``>>
+
+        member this.StartDate =
+            let startPoint (FixedTimeSeries(_,s, _)) = s
+            this |> startPoint
+
+        member this.DateMode = this |> fun (FixedTimeSeries(m,_,_)) -> m
+
+
+    let private innerSeries (FixedTimeSeries(_,s, TimeSteps ts)) = ts
+    let private unwrap (FixedTimeSeries(_,s, TimeSteps ts)) = (s, ts)
+    let private createFixedSeries dateType start series = (dateType, start, series) |> FixedTimeSeries
+
+    /// Arrange existing observations as a bristlecone `TimeSeries`.
+    /// Observations become ordered and indexed by time.
+    let fromObservations (dateType:DateMode.DateMode<'date,'dateUnit,'timespan>) (dataset: seq<Observation<'T, 'date>>) =
+        if dataset |> Seq.length < 2 then
+            invalidArg "dataset" "The data must be at least two elements long"
+
+        let sorted = dataset |> Seq.sortBy snd
+        let baseline : Observation<'T, 'date> = sorted |> Seq.head
+
+        let timePoints =
+            sorted
+            |> Seq.tail // The first time point is used as initial state in the scan
+            |> Seq.scan
+                (fun (_, d1: 'date, _) (v2, d2: 'date) ->
+                    (v2, d2, Some (d2 - d1)))
+                (baseline |> fst, baseline |> snd, None)
+            |> Seq.tail // The first time point is removed (it forms the baseline instead)
+            |> Seq.map (fun (v, _, ts) -> (v, ts.Value))
+            |> Seq.toArray
+            |> TimeSteps
+
+        FixedTimeSeries(dateType, baseline, timePoints)
+
+    /// Create a time series from a sequence of existing data, where each
+    /// observation is equally spaced in time.
+    let fromSeq (timeUnitMode:DateMode.DateMode<'date,'b,'timespan>) t1 resolution (data: seq<'a>) =
+        data
+        |> Seq.tail // The first time point is used as initial state for the scan
+        |> Seq.scan (fun (_, t) v -> (v, t |> TimePoint.increment resolution timeUnitMode)) (data |> Seq.head, t1)
+        |> fromObservations timeUnitMode
+
+    /// Turn a time series into a sequence of observations
+    let toObservations (series:TimeSeries<'a,'b,'c,'d>) =
+        let baseline, ts = unwrap series
+        ts |> Seq.scan (fun (_, lastDate) (v, ts) -> (v, lastDate + ts)) baseline
+
+    /// Map a function to each value in the time series.
+    let map f series =
+        series
+        |> innerSeries
+        |> Array.map (fun (v, ts) -> (f (v, ts), ts))
+        |> TimeSteps
+        |> createFixedSeries series.DateMode (f (series.StartDate |> fst, series.DateMode.ZeroSpan), series.StartDate |> snd)
+
+    /// The time intervals - or *epochs* - that form the time series.
+    let epochs series = series |> innerSeries |> Array.map snd
+
+    let checkMoreThanEqualTo n seq =
+        if seq |> Seq.length >= n then Some seq else None
+
+    /// Remove all time points that occur before the desired start date.
+    let trimStart startDate series =
+        let obs = series |> toObservations
+
+        match obs |> Seq.tryFindIndex (fun (_, t) -> t >= startDate) with
+        | Some startIndex ->
+            obs
+            |> Seq.toArray
+            |> Array.splitAt startIndex
+            |> snd
+            |> checkMoreThanEqualTo 2
+            |> Option.map (fromObservations series.DateMode)
+        | None -> None
+
+    /// Remove all time points that occur after the desired end date.
+    let trimEnd endDate series =
+        series
+        |> toObservations
+        |> Seq.takeWhile (fun (_, t) -> t <= endDate)
+        |> checkMoreThanEqualTo 2
+        |> Option.map (fromObservations series.DateMode)
+
+    /// Bound a time series inclusively
+    let bound startDate endDate series =
+        series
+        |> toObservations
+        |> Seq.skipWhile (fun (_, t) -> t < startDate)
+        |> Seq.takeWhile (fun (_, t) -> t <= endDate)
+        |> checkMoreThanEqualTo 2
+        |> Option.map (fromObservations series.DateMode)
+
+    /// Date of the last observation within the time series.
+    let endDate series =
+        series |> toObservations |> Seq.last |> snd
+
+    /// Time points of sampling within the time series.
+    let dates series = series |> toObservations |> Seq.map snd
+
+    /// Find an observation by its exact time of occurrence.
+    let findExact time series =
+        series |> toObservations |> Seq.find (fun (v, t) -> t = time)
+
+    /// Calculates the temporal resolution of a time series
+    let resolution series =
+        let epochs = series |> epochs
+
+        if epochs |> Seq.distinct |> Seq.length = 1 then // There is a fixed time period.
+            let fixedEpoch = epochs |> Seq.head
+
+            if fixedEpoch = series.DateMode.ZeroSpan then
+                failwith "Cannot have a resolution of zero"
+
+            if (series.DateMode.TotalDays fixedEpoch) % 1.<day> = 0.<day> then
+                Resolution.Fixed
+                <| Resolution.FixedTemporalResolution.Days(PositiveInt.create (series.DateMode.TotalDays fixedEpoch |> Units.floatToInt) |> Option.get)
+            else
+                Resolution.Fixed
+                <| Resolution.FixedTemporalResolution.CustomEpoch fixedEpoch
+        else // A variable time interval exists. This could be months, years, or some other unit.
+            let observations = series |> toObservations
+            let startDate = observations |> Seq.head |> snd
+
+            match series.DateMode.Resolution with
+            | DateMode.MaximumResolution.Ticks (_, getMonth) ->
+
+                let monthDifferences =
+                    observations
+                    |> Seq.map snd
+                    |> Seq.tail
+                    |> Seq.scan
+                        (fun (t1, m) t2 -> (t2, (series.DateMode.GetYear t2 * 12) + getMonth t2))
+                        (startDate, (series.DateMode.GetYear startDate * 12) + getMonth startDate)
+                    |> Seq.map snd
+                    |> Seq.pairwise
+                    |> Seq.map (fun (m1, m2) -> m2 - m1)
+
+                if monthDifferences |> Seq.distinct |> Seq.length = 1 then // There is a fixed monthly stepping
+                    let fixedMonths = monthDifferences |> Seq.head
+
+                    if fixedMonths % 12 = 0 then
+                        Resolution.Fixed
+                        <| Resolution.FixedTemporalResolution.Years(PositiveInt.create (fixedMonths / 12) |> Option.get)
+                    else
+                        Resolution.Fixed
+                        <| Resolution.FixedTemporalResolution.Months(PositiveInt.create fixedMonths |> Option.get)
+                else // The time series has variable increments not on day or month cycle
+                    Resolution.Variable
+            | DateMode.MaximumResolution.Year ->
+
+                let yearDifferences =
+                    observations
+                    |> Seq.map(fun t -> t |> snd |> series.DateMode.GetYear)
+                    |> Seq.pairwise
+                    |> Seq.map (fun (m1, m2) -> m2 - m1)
+
+                if yearDifferences |> Seq.distinct |> Seq.length = 1 then
+                    let fixedYears = (yearDifferences |> Seq.head) * 1<year>
+                    Resolution.Fixed
+                    <| Resolution.FixedTemporalResolution.Years(PositiveInt.create fixedYears |> Option.get)
+                else Resolution.Variable
+
+
+    /// Reduces the temporal resolution of `series`.
+    /// The time series must be able to be split exactly into the lower resolution. For example,
+    /// when upscaling from one to three years, the time series must be a multiple of three years.
+    let generalise desiredResolution (upscaleFunction: seq<Observation<'T,'date>> -> 'T2) (series: TimeSeries<'T,'date,'timeunit,'timespan>) =
+        let resolution = series |> resolution
+        let obs = series |> toObservations
+
+        match resolution with
+        | Resolution.Variable -> invalidArg "desiredResolution" "Cannot generalise a variable-resolution time series"
+        | Resolution.Fixed res ->
+            match res with
+            | Resolution.FixedTemporalResolution.Years oldYears ->
+                match desiredResolution with
+                | Resolution.FixedTemporalResolution.Years newYears ->
+                    if
+                        newYears > oldYears
+                        && ((float newYears.Value) % (float oldYears.Value) = 0.)
+                        && ((obs |> Seq.length |> float) % (float newYears.Value) = 0.)
+                    then
+                        obs
+                        |> Seq.chunkBySize (newYears.Value / oldYears.Value)
+                        |> Seq.map (fun bin -> (bin |> upscaleFunction, bin |> Seq.head |> snd))
+                        |> fromObservations series.DateMode
+                    else
+                        invalidArg
+                            "desiredResolution"
+                            "The upscaled resolution was not a whole multiple of the old resolution"
+                | _ -> invalidArg "desiredResolution" "Cannot generalise an annual time series to a lower resolution"
+            | Resolution.FixedTemporalResolution.Days oldDays ->
+                match desiredResolution with
+                | Resolution.FixedTemporalResolution.Months newMonths ->
+                    match series.DateMode.Resolution with
+                    | DateMode.MaximumResolution.Year -> invalidArg "series" "Cannot generalise a series that uses year-based dating to monthly resolution"
+                    | DateMode.MaximumResolution.Ticks (_, getMonth) ->
+                        obs
+                        |> Seq.groupBy (fun (_, t) -> (series.DateMode.GetYear t, getMonth t))
+                        |> Seq.map (fun ((y, m), g) -> (g |> upscaleFunction, g |> Seq.map snd |> Seq.max))
+                        |> fromObservations series.DateMode
+                | Resolution.FixedTemporalResolution.Years _
+                | Resolution.FixedTemporalResolution.Days _
+                | Resolution.FixedTemporalResolution.CustomEpoch _ ->
+                    invalidArg "desiredResolution" "Generalising to [year/day/custom-epoch] resolution is currently unsupported"
+            | Resolution.FixedTemporalResolution.Months _
+            | Resolution.FixedTemporalResolution.CustomEpoch _ ->
+                invalidArg "series" "Generalising a monthly or custom-epoch series is currently unsupported"
+
+    /// Interpolates missing values in a time series, where missing values
+    /// are represented as an `Option` type.
+    let interpolate (series: TimeSeries<'T,'a,'b,'c>) =
+        let observations = series |> toObservations |> Seq.toArray
+
+        observations
+        |> Seq.mapi (fun i obs ->
+            match fst obs with
+            | Some _ -> Some(obs, i, i, i)
+            | None ->
+                let lastIndex =
+                    observations |> Seq.take i |> Seq.tryFindIndexBack (fun (o, _) -> o.IsSome)
+
+                let nextIndex =
+                    observations |> Seq.skip i |> Seq.tryFindIndex (fun (o, _) -> o.IsSome)
+
+                if lastIndex.IsSome && nextIndex.IsSome then
+                    Some(obs, i, lastIndex.Value, nextIndex.Value + i)
+                else
+                    None)
+        |> Seq.choose id
+        |> Seq.map (fun (obs, i, last, next) ->
+            if (next - last) = 0 then
+                (observations.[i] |> fst).Value, observations.[i] |> snd
+            else
+                let lastValue = (observations.[last] |> fst).Value
+                let nextValue = (observations.[next] |> fst).Value
+
+                (lastValue
+                 + ((nextValue - lastValue) / (float next - float last)) * (float i - float last)),
+                (obs |> snd))
+        |> fromObservations series.DateMode
+
+    /// <summary>Determines if multiple time series have the same temporal extent and time steps.</summary>
+    /// <param name="series">A sequence of `TimeSeries`</param>
+    /// <returns>A `TimeSpan [] option` containing the epochs of the common timeline, 
+    /// or `None` if there is no common timeline.</returns>
+    let commonTimeline series =
+        let timeSteps = series |> Seq.map (toObservations >> Seq.map snd >> Seq.toList) |> Seq.toList
+
+        match timeSteps with
+        | Single
+        | AllIdentical -> Some(series |> Seq.head |> epochs)
+        | Empty
+        | Neither -> None
+
+    /// Contains functions for bootstrapping one or many time series.
+    module Bootstrap =
+
+        /// <summary> Removes a single observation from a time-series.
+        /// For relevant date types, removing a step takes account of leap years.
+        /// The starting point is never removed.</summary>
+        /// <param name="stepping"></param>
+        /// <param name="i"></param>
+        /// <param name="series"></param>
+        /// <returns>A time series that has the observation at position i removed</returns>
+        let bootstrapFixedStep stepping i series =
+            let start, _ = series |> unwrap
+
+            let newData =
+                series
+                |> innerSeries
+                |> Array.map fst
+                |> Array.toList
+                |> List.remove i
+                |> List.toArray
+
+            (List.init (Seq.length newData) (fun _ -> stepping))
+            |> Seq.zip newData
+            |> Seq.toArray
+            |> TimeSteps
+            |> createFixedSeries series.DateMode start
+
+        /// <summary>Randomly remove a single time point from a time-series.</summary>
+        /// <param name="random">A random instance to use</param>
+        /// <param name="data">A map where the values correspond to time series, with at least one entry.</param>
+        /// <returns></returns>
+        let removeSingle (random: System.Random) data =
+            let commonTimeSeries =
+                commonTimeline (data |> Map.toList |> List.map snd)
+
+            match commonTimeSeries with
+            | None -> invalidOp "The time series are not on common time"
+            | Some ts ->
+                match ts.Length with
+                | 0 -> invalidOp "The time series was empty"
+                | _ ->
+                    let selection = random.Next(0, ts.Length - 1)
+
+                    data
+                    |> Map.map (fun _ v -> v |> bootstrapFixedStep (TimeSpan.FromDays(366.)) selection)
+
+
+    type TimeSeries<'T, 'date, 'timeunit, 'timespan> with
+        member this.Resolution = this |> resolution
+        member this.Length = this |> innerSeries |> Array.length
+
+        member this.Head = this |> innerSeries |> Array.head
+
+        member this.TimeSteps = this |> innerSeries |> Array.map snd
+
+        member this.Values = this |> toObservations |> Seq.map fst
+
+
+type TimeSeries<'T, 'date, 'timeunit, 'timespan> = TimeSeries.TimeSeries<'T, 'date, 'timeunit, 'timespan>
+
+
+module TimeIndex =
+
+    /// When using a time index, if a value is requested within the bounds
+    /// of the time-series but not falling on an observed time, a lookup
+    /// value may be interpolated using an interpolation function. Here,
+    /// `'T` is the data value type.
+    type IndexMode<'T> =
+        | Interpolate of ((float<``time index``> * 'T) -> (float<``time index``> * 'T) -> float<``time index``> -> 'T)
+        | Exact
 
     /// Indexes the time series in accordance with a `baselineTime` and fixed `resolution`.
     /// Where the time series is of a lower resolution
-    let indexSeries (t0: DateTime) targetResolution (series: TimeSeries<'a>) : seq<float * 'a> =
+    let indexSeries (t0: DatingMethods.Radiocarbon) targetResolution (series: TimeSeries<'T, 'date, 'timeunit, 'timespan>) : seq<float<``time index``> * 'a> =
         let obs = series |> TimeSeries.toObservations
 
-        match targetResolution with
-        | FixedTemporalResolution.Years y ->
-            obs |> Seq.map (fun (v, tn) -> (((totalYearsElapsed t0 tn) / float y.Value), v))
-        | FixedTemporalResolution.Months m ->
-            obs
-            |> Seq.map (fun (v, tn) -> (((totalMonthsElapsed t0 tn) / float m.Value), v))
-        | FixedTemporalResolution.Days d -> obs |> Seq.map (fun (v, tn) -> (((tn - t0).TotalDays / float d.Value), v))
-        | FixedTemporalResolution.CustomEpoch t ->
-            obs
-            |> Seq.map (fun (v, tn) -> ((((tn - t0).Ticks / t.Value.Ticks) |> float), v))
+        match series.DateMode.Resolution with
+        | DateMode.MaximumResolution.Ticks (getDay, getMonth) ->
+            match targetResolution with
+            | Resolution.FixedTemporalResolution.Years y ->
+                obs 
+                |> Seq.map (fun (v, tn) ->
+                    (((DateTime.totalYearsElapsed t0 tn) / y.Value), v))
+            | Resolution.FixedTemporalResolution.Months m ->
+                obs
+                |> Seq.map (fun (v, tn) -> (((DateTime.totalMonthsElapsed t0 tn) / float m.Value), v))
+            | Resolution.FixedTemporalResolution.Days d -> obs |> Seq.map (fun (v, tn) -> (((tn - t0).TotalDays / float d.Value), v))
+            | Resolution.FixedTemporalResolution.CustomEpoch t ->
+                obs
+                |> Seq.map (fun (v, tn) -> ((((tn - t0).Ticks / t.Value.Ticks) |> float), v))
 
-    /// A representation of temporal data as fractions of a common fixed temporal resolution,
+        | DateMode.MaximumResolution.Year ->
+            match targetResolution with
+            | Resolution.FixedTemporalResolution.Years y ->
+                obs 
+                |> Seq.map (fun (value, tn) -> 
+                    ((float (tn - t0) / float y.Value) * 1.0<``time index``>, value))
+            | Resolution.FixedTemporalResolution.CustomEpoch t ->
+                obs 
+                |> Seq.map (fun (value, tn) -> 
+                    ((float (tn - t0) / t) * 1.0<``time index``>, value))
+            | Resolution.FixedTemporalResolution.Months _
+            | Resolution.FixedTemporalResolution.Days _ ->
+                failwith "Cannot index timeseries that has a maximum resolution of annual by month / day."
+
+
+
+    /// <summary>A representation of temporal data as fractions of a common fixed temporal resolution,
     /// from a given baseline. The baseline must be greater than or equal to the baseline
-    /// of the time series.
-    type TimeIndex<'a>(baseDate, resolution, mode, series: TimeSeries<'a>) =
+    /// of the time series.</summary>
+    type TimeIndex<'T>(baseDate: 'date, resolution, mode: IndexMode<'T>, series: TimeSeries<'T, 'date, 'timeunit, 'timespan>) =
         let table = series |> indexSeries baseDate resolution |> Map.ofSeq
         let tablePairwise = table |> Map.toArray |> Array.pairwise // Ordered in time
 
         member __.Item
 
-            with get (t): 'a =
+            with get (t) : 'T =
                 match mode with
                 | Exact -> table.[t]
-                | Interpolate i ->
+                | Interpolate interpolateFn ->
                     if table.ContainsKey t then
                         table.[t]
                     else
                         // Find the closest points in the index before and after t
                         match
                             tablePairwise
-                            |> Array.tryFind (fun ((k1, _), (k2, _)) -> (t - k1) > 0. && (t - k2) < 0.)
+                            |> Array.tryFind (fun ((k1, _), (k2, _)) -> (t - k1) > 0.<``time index``> && (t - k2) < 0.<``time index``>)
                         with
-                        | Some((k1, v1), (k2, v2)) -> i (k1, v1) (k2, v2) t
+                        | Some((k1, v1), (k2, v2)) -> interpolateFn (k1, v1) (k2, v2) t
                         | None ->
                             invalidOp
                             <| sprintf
@@ -460,7 +651,7 @@ module TimeIndex =
 [<RequireQualifiedAccess>]
 module TimeFrame =
 
-    type TimeFrame<'a> = private TimeFrame of CodedMap<TimeSeries.TimeSeries<'a>>
+    type TimeFrame<'T, 'date, 'timeunit, 'timespan> = private TimeFrame of CodedMap<TimeSeries.TimeSeries<'T, 'date, 'timeunit, 'timespan>>
 
     let tryCreate series =
         let commonTimeline =
@@ -470,24 +661,22 @@ module TimeFrame =
         | Some _ -> TimeFrame series |> Some
         | None -> None
 
-    let inner (TimeFrame frame) = frame
+    let private inner (TimeFrame frame) = frame
 
-    type TimeFrame<'a> with
+    type TimeFrame<'T, 'date, 'timeunit, 'timespan> with
         member this.Resolution = (this |> inner |> Seq.head).Value.Resolution
         member this.StartDate = (this |> inner |> Seq.head).Value.StartDate |> snd
         member this.Series = this |> inner
 
 
+/// <summary>A specific type of time series that represents
+/// growth in a phenomena over time.</summary>
 [<RequireQualifiedAccess>]
 module GrowthSeries =
 
-    type GrowthSeries<[<Measure>] 'u> =
-        | Cumulative of TimeSeries<float<'u>>
-        | Absolute of TimeSeries<float<'u>>
-        | Relative of TimeSeries<float<'u>>
+    [<Measure>] type mm
 
-    let growthToTime growth =
-        match growth with
-        | Absolute g -> g
-        | Cumulative g -> g
-        | Relative g -> g
+    type GrowthSeries<[<Measure>] 'u, [<Measure>] 'time, 'date, 'timeunit, 'timespan> =
+        | Cumulative of TimeSeries<float<'u>,'date,'timeunit, 'timespan>
+        | Absolute of TimeSeries<float<'u / 'time>,'date,'timeunit, 'timespan>
+        | Relative of TimeSeries<float<'u / 'u>,'date,'timeunit, 'timespan>

--- a/src/Bristlecone/Types.fs
+++ b/src/Bristlecone/Types.fs
@@ -45,25 +45,6 @@ module PositiveInt =
 
 
 [<RequireQualifiedAccess>]
-module RealTimeSpan =
-
-    open System
-
-    type RealTimeSpan = private RealTimeSpan of TimeSpan
-
-    let create t =
-        if t = TimeSpan.Zero then
-            None
-        else
-            t |> RealTimeSpan |> Some
-
-    let private unwrap (RealTimeSpan t) = t
-
-    type RealTimeSpan with
-        member this.Value = unwrap this
-
-
-[<RequireQualifiedAccess>]
 module ShortCode =
 
     type ShortCode = private ShortCode of string
@@ -78,7 +59,6 @@ module ShortCode =
         member this.Value = unwrap this
 
 
-type RealTimeSpan = RealTimeSpan.RealTimeSpan
 type CodedMap<'T> = Map<ShortCode.ShortCode, 'T>
 
 module Conditioning =

--- a/src/Bristlecone/Types.fs
+++ b/src/Bristlecone/Types.fs
@@ -8,8 +8,13 @@ do ()
 module internal Units =
 
     let removeUnitFromInt (v: int<_>) = int v
+    let removeUnitFromFloat (v: float<_>) = float v
     let floatToInt (x:float<'u>) : int<'u> =
         x |> int |> LanguagePrimitives.Int32WithMeasure
+    let intToFloat (x:int<'u>) : float<'u> =
+        x |> float |> LanguagePrimitives.FloatWithMeasure
+
+    let round<[<Measure>]'u>(x: float<'u>): float<'u> = System.Math.Round(float x) |> LanguagePrimitives.FloatWithMeasure
 
 
 [<RequireQualifiedAccess>]

--- a/src/Bristlecone/Types.fs
+++ b/src/Bristlecone/Types.fs
@@ -9,20 +9,26 @@ module internal Units =
 
     let removeUnitFromInt (v: int<_>) = int v
     let removeUnitFromFloat (v: float<_>) = float v
-    let floatToInt (x:float<'u>) : int<'u> =
+
+    let floatToInt (x: float<'u>) : int<'u> =
         x |> int |> LanguagePrimitives.Int32WithMeasure
-    let intToFloat (x:int<'u>) : float<'u> =
+
+    let intToFloat (x: int<'u>) : float<'u> =
         x |> float |> LanguagePrimitives.FloatWithMeasure
 
-    let round<[<Measure>]'u>(x: float<'u>): float<'u> = System.Math.Round(float x) |> LanguagePrimitives.FloatWithMeasure
+    let round<[<Measure>] 'u> (x: float<'u>) : float<'u> =
+        System.Math.Round(float x) |> LanguagePrimitives.FloatWithMeasure
 
+
+[<Measure>]
+type iteration
 
 [<RequireQualifiedAccess>]
 module PositiveInt =
 
     type PositiveInt<[<Measure>] 'm> = private PositiveInt of int<'m>
 
-    let private (|Positive|Negative|Zero|) (num:int<_>) =
+    let private (|Positive|Negative|Zero|) (num: int<_>) =
         if num > 0<_> then Positive
         elif num < 0<_> then Negative
         else Zero

--- a/src/Bristlecone/Types.fs
+++ b/src/Bristlecone/Types.fs
@@ -5,14 +5,21 @@ open System.Runtime.CompilerServices
 [<assembly: InternalsVisibleTo("Bristlecone.Tests")>]
 do ()
 
+module internal Units =
+
+    let removeUnitFromInt (v: int<_>) = int v
+    let floatToInt (x:float<'u>) : int<'u> =
+        x |> int |> LanguagePrimitives.Int32WithMeasure
+
+
 [<RequireQualifiedAccess>]
 module PositiveInt =
 
-    type PositiveInt = private PositiveInt of int
+    type PositiveInt<[<Measure>] 'm> = private PositiveInt of int<'m>
 
-    let private (|Positive|Negative|Zero|) num =
-        if num > 0 then Positive
-        elif num < 0 then Negative
+    let private (|Positive|Negative|Zero|) (num:int<_>) =
+        if num > 0<_> then Positive
+        elif num < 0<_> then Negative
         else Zero
 
     let create i =
@@ -22,8 +29,9 @@ module PositiveInt =
 
     let private unwrap (PositiveInt p) = p
 
-    type PositiveInt with
+    type PositiveInt<'u> with
         member this.Value = unwrap this
+
 
 [<RequireQualifiedAccess>]
 module RealTimeSpan =
@@ -60,7 +68,6 @@ module ShortCode =
 
 
 type RealTimeSpan = RealTimeSpan.RealTimeSpan
-type PositiveInt = PositiveInt.PositiveInt
 type CodedMap<'T> = Map<ShortCode.ShortCode, 'T>
 
 module Conditioning =

--- a/src/Bristlecone/Types.fs
+++ b/src/Bristlecone/Types.fs
@@ -3,6 +3,7 @@ namespace Bristlecone
 open System.Runtime.CompilerServices
 
 [<assembly: InternalsVisibleTo("Bristlecone.Tests")>]
+[<assembly: InternalsVisibleTo("Bristlecone.Dendro")>]
 do ()
 
 module internal Units =

--- a/src/Bristlecone/Workflow.fs
+++ b/src/Bristlecone/Workflow.fs
@@ -9,10 +9,10 @@ module Orchestration =
     open Bristlecone.ModelSystem
     open System.Collections.Generic
 
-    type OrchestrationMessage =
-        | StartWorkPackage of Async<EstimationResult>
-        | StartDependentWorkPackages of Async<EstimationResult>
-        | Finished of EstimationResult
+    type OrchestrationMessage<'date, 'timeunit, 'timespan> =
+        | StartWorkPackage of Async<EstimationResult<'date, 'timeunit, 'timespan>>
+        | StartDependentWorkPackages of Async<EstimationResult<'date, 'timeunit, 'timespan>>
+        | Finished of EstimationResult<'date, 'timeunit, 'timespan>
         | WorkFailed of exn
         | WorkCancelled
 

--- a/src/Bristlecone/Workflow.fs
+++ b/src/Bristlecone/Workflow.fs
@@ -20,10 +20,10 @@ module Orchestration =
 
     /// The `OrchestrationAgent` queues work items of the type `Async<EstimationResult>`, which
     /// are run in parallel up to a total of `maxSimultaneous` at one time.
-    type OrchestrationAgent(writeOut, maxSimultaneous, retainResults) =
+    type OrchestrationAgent<'date, 'timeunit, 'timespan>(writeOut, maxSimultaneous, retainResults) =
 
-        let queue = Queue<_>()
-        let results = Queue<_>()
+        let queue: Queue<Async<EstimationResult<'date, 'timeunit, 'timespan>>> = Queue<_>()
+        let results: Queue<EstimationResult<'date, 'timeunit, 'timespan>> = Queue<_>()
 
         let agent =
             MailboxProcessor.Start(fun inbox ->

--- a/tests/Bristlecone.Benchmark/Program.fs
+++ b/tests/Bristlecone.Benchmark/Program.fs
@@ -211,7 +211,7 @@ module TimeSeriesTests =
         |> Bristlecone.Language.Test.withStartValue "lynx" 1.0
         |> Bristlecone.Language.Test.withStartValue "hare" 1.0
 
-    let summarise modelName optimName (results: (Result<Bristlecone.Test.TestResult, string> * int) seq) =
+    let summarise modelName optimName (results: (Result<Bristlecone.Test.TestResult<'a, 'b, 'c>, string> * int) seq) =
         let successes =
             results
             |> Seq.toList
@@ -276,7 +276,7 @@ let optimFunctions =
       "random walk w/ tuning",
       MonteCarlo.randomWalk [ MonteCarlo.TuneMethod.CovarianceWithScale 0.25, 500, EndConditions.afterIteration 10000 ] ]
 
-let timeModels =
+let timeModels: (string * Bristlecone.ModelSystem.ModelSystem<float> * (Bristlecone.Test.TestSettings<float,obj,obj,obj> -> Bristlecone.Test.TestSettings<float,obj,obj,obj>)) list =
     [ "predator-prey (with gaussian noise)",
       TestFunctions.Timeseries.``predator-prey [with noise]``,
       Bristlecone.Test.addStartValues [ "lynx", 1.0; "hare", 1.0 ]

--- a/tests/Bristlecone.Benchmark/Program.fs
+++ b/tests/Bristlecone.Benchmark/Program.fs
@@ -276,7 +276,10 @@ let optimFunctions =
       "random walk w/ tuning",
       MonteCarlo.randomWalk [ MonteCarlo.TuneMethod.CovarianceWithScale 0.25, 500, EndConditions.afterIteration 10000 ] ]
 
-let timeModels: (string * Bristlecone.ModelSystem.ModelSystem<float> * (Bristlecone.Test.TestSettings<float,obj,obj,obj> -> Bristlecone.Test.TestSettings<float,obj,obj,obj>)) list =
+let timeModels
+    : (string *
+      Bristlecone.ModelSystem.ModelSystem<float> *
+      (Bristlecone.Test.TestSettings<float, obj, obj, obj> -> Bristlecone.Test.TestSettings<float, obj, obj, obj>)) list =
     [ "predator-prey (with gaussian noise)",
       TestFunctions.Timeseries.``predator-prey [with noise]``,
       Bristlecone.Test.addStartValues [ "lynx", 1.0; "hare", 1.0 ]

--- a/tests/Bristlecone.Tests/Bristlecone.Tests.fsproj
+++ b/tests/Bristlecone.Tests/Bristlecone.Tests.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Bristlecone/Bristlecone.fsproj" />
+    <ProjectReference Include="../../src/Bristlecone.Dendro/Bristlecone.Dendro.fsproj" />
     <Compile Include="Config.fs" />
     <Compile Include="Time.fs" />
     <Compile Include="Parameter.fs" />
@@ -17,6 +18,7 @@
     <Compile Include="Test.fs" />
     <Compile Include="Bristlecone.fs" />
     <Compile Include="Language.fs" />
+    <Compile Include="Dendro.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/tests/Bristlecone.Tests/Bristlecone.Tests.fsproj
+++ b/tests/Bristlecone.Tests/Bristlecone.Tests.fsproj
@@ -8,8 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/Bristlecone/Bristlecone.fsproj" />
-    <ProjectReference Include="../../src/Bristlecone.Dendro/Bristlecone.Dendro.fsproj" />
-    <ProjectReference Include="../../src/Bristlecone.Charts.R/Bristlecone.Charts.R.fsproj" />
     <Compile Include="Config.fs" />
     <Compile Include="Time.fs" />
     <Compile Include="Parameter.fs" />

--- a/tests/Bristlecone.Tests/Bristlecone.fs
+++ b/tests/Bristlecone.Tests/Bristlecone.fs
@@ -120,7 +120,11 @@ module ``Fit`` =
                   else
                       let data =
                           [ (Language.code "x").Value,
-                            Time.TimeSeries.fromSeq Time.DateMode.calendarDateMode time (Time.Resolution.FixedTemporalResolution.Years resolution) data ]
+                            Time.TimeSeries.fromSeq
+                                Time.DateMode.calendarDateMode
+                                time
+                                (Time.Resolution.FixedTemporalResolution.Years resolution)
+                                data ]
                           |> Map.ofList
 
                       let result = Bristlecone.Fit.t0 data Conditioning.RepeatFirstDataPoint ignore
@@ -158,7 +162,11 @@ module ``Fit`` =
                         else
                             let data =
                                 [ (Language.code "x").Value,
-                                  Time.TimeSeries.fromSeq Time.DateMode.calendarDateMode startDate (Time.Resolution.FixedTemporalResolution.Months months) obs ]
+                                  Time.TimeSeries.fromSeq
+                                      Time.DateMode.calendarDateMode
+                                      startDate
+                                      (Time.Resolution.FixedTemporalResolution.Months months)
+                                      obs ]
                                 |> Map.ofList
 
                             let result =
@@ -253,7 +261,11 @@ module ``Fit`` =
                                 [ (ShortCode.create "x").Value; (ShortCode.create "y").Value ]
                                 |> Seq.map (fun c ->
                                     c,
-                                    Time.TimeSeries.fromSeq Time.DateMode.calendarDateMode startDate (Time.Resolution.FixedTemporalResolution.Months months) data)
+                                    Time.TimeSeries.fromSeq
+                                        Time.DateMode.calendarDateMode
+                                        startDate
+                                        (Time.Resolution.FixedTemporalResolution.Months months)
+                                        data)
                                 |> Map.ofSeq
 
                             let result =

--- a/tests/Bristlecone.Tests/Bristlecone.fs
+++ b/tests/Bristlecone.Tests/Bristlecone.fs
@@ -60,7 +60,7 @@ module ``Objective creation`` =
               <| fun shouldTransform (data: float list) (b1: NormalFloat) (b2: NormalFloat) ->
 
                   // Returns the parameter value
-                  let fakeLikelihood: Bristlecone.ModelSystem.LikelihoodFn =
+                  let fakeLikelihood: Bristlecone.ModelSystem.LikelihoodFn<float> =
                       fun paramAccessor data -> paramAccessor.Get "a"
 
                   if b1.Get = b2.Get || b1.Get = 0. || b2.Get = 0. then
@@ -101,6 +101,10 @@ module ``Objective creation`` =
 
               ]
 
+type TimeModeToTest =
+    | TestCalendarDate
+    | TestRadiocarbon
+
 module ``Fit`` =
 
     [<Tests>]
@@ -116,7 +120,7 @@ module ``Fit`` =
                   else
                       let data =
                           [ (Language.code "x").Value,
-                            Time.TimeSeries.fromSeq time (Time.FixedTemporalResolution.Years resolution) data ]
+                            Time.TimeSeries.fromSeq Time.DateMode.calendarDateMode time (Time.Resolution.FixedTemporalResolution.Years resolution) data ]
                           |> Map.ofList
 
                       let result = Bristlecone.Fit.t0 data Conditioning.RepeatFirstDataPoint ignore
@@ -152,9 +156,9 @@ module ``Fit`` =
                         then
                             ()
                         else
-                            let data: CodedMap<Time.TimeSeries.TimeSeries<float>> =
+                            let data =
                                 [ (Language.code "x").Value,
-                                  Time.TimeSeries.fromSeq startDate (Time.FixedTemporalResolution.Months months) obs ]
+                                  Time.TimeSeries.fromSeq Time.DateMode.calendarDateMode startDate (Time.Resolution.FixedTemporalResolution.Months months) obs ]
                                 |> Map.ofList
 
                             let result =
@@ -249,7 +253,7 @@ module ``Fit`` =
                                 [ (ShortCode.create "x").Value; (ShortCode.create "y").Value ]
                                 |> Seq.map (fun c ->
                                     c,
-                                    Time.TimeSeries.fromSeq startDate (Time.FixedTemporalResolution.Months months) data)
+                                    Time.TimeSeries.fromSeq Time.DateMode.calendarDateMode startDate (Time.Resolution.FixedTemporalResolution.Months months) data)
                                 |> Map.ofSeq
 
                             let result =

--- a/tests/Bristlecone.Tests/Config.fs
+++ b/tests/Bristlecone.Tests/Config.fs
@@ -68,15 +68,24 @@ type BristleconeTypesGen() =
         |> Gen.map (PositiveInt.create >> Option.get)
         |> Arb.fromGen
 
-    static member RealTimeSpan =
-        Gen.choose (1, Int32.MaxValue)
-        |> Gen.map (int64 >> TimeSpan.FromTicks >> RealTimeSpan.create >> Option.get)
+    static member ObservationalTimeSpan =
+        Gen.choose (1, TimeSpan.TicksPerDay * int64 (365*200) |> int)
+        |> Gen.map (int64 >> TimeSpan.FromTicks >> Time.ObservationalTimeSpan.create >> Option.get)
         |> Arb.fromGen
 
     static member Observations: Arbitrary<(float * DateTime) list> =
         gen {
             let! length = Gen.choose (2, 100)
             let! list1 = Gen.listOfLength length Arb.generate<DateTime>
+            let! list2 = Gen.listOfLength length (Arb.generate<NormalFloat> |> Gen.map (fun f -> f.Get))
+            return List.zip list2 list1
+        }
+        |> Arb.fromGen
+
+    static member ObservationsBP: Arbitrary<(float * int<Time.``BP (radiocarbon)``>) list> =
+        gen {
+            let! length = Gen.choose (2, 100)
+            let! list1 = Gen.listOfLength length Arb.generate<int<Time.``BP (radiocarbon)``>>
             let! list2 = Gen.listOfLength length (Arb.generate<NormalFloat> |> Gen.map (fun f -> f.Get))
             return List.zip list2 list1
         }

--- a/tests/Bristlecone.Tests/Config.fs
+++ b/tests/Bristlecone.Tests/Config.fs
@@ -37,7 +37,7 @@ type BristleconeTypesGen() =
     static member EquationList = genStrings 1 10 |> genTuple<ModelExpression> |> Arb.fromGen
 
     static member MeasureList =
-        genStrings 1 10 |> genTuple<ModelSystem.MeasureEquation> |> Arb.fromGen
+        genStrings 1 10 |> genTuple<ModelSystem.Measurement<float>> |> Arb.fromGen
 
     static member Pool =
         gen {
@@ -63,7 +63,7 @@ type BristleconeTypesGen() =
 
     static member Floats() : Arbitrary<float list> = genMultiList 2 1000 |> Arb.fromGen
 
-    static member PositveInt: Arbitrary<PositiveInt.PositiveInt> =
+    static member PositveInt: Arbitrary<PositiveInt.PositiveInt<1>> =
         Gen.choose (1, 5) //Int32.MaxValue)
         |> Gen.map (PositiveInt.create >> Option.get)
         |> Arb.fromGen

--- a/tests/Bristlecone.Tests/Config.fs
+++ b/tests/Bristlecone.Tests/Config.fs
@@ -69,7 +69,7 @@ type BristleconeTypesGen() =
         |> Arb.fromGen
 
     static member ObservationalTimeSpan =
-        Gen.choose (1, TimeSpan.TicksPerDay * int64 (365*200) |> int)
+        Gen.choose (1, TimeSpan.TicksPerDay * int64 (365 * 200) |> int)
         |> Gen.map (int64 >> TimeSpan.FromTicks >> Time.ObservationalTimeSpan.create >> Option.get)
         |> Arb.fromGen
 

--- a/tests/Bristlecone.Tests/Dendro.fs
+++ b/tests/Bristlecone.Tests/Dendro.fs
@@ -1,0 +1,26 @@
+module DendroTests
+
+open System
+open Expecto
+open Bristlecone
+open Bristlecone.Dendro
+open FsCheck
+
+let config = Config.config
+
+[<Tests>]
+let sunrise =
+    testList
+        "Sunrise calculations"
+        [
+            testCase "Complete dark during polar winter" <| fun _ ->
+
+                let result =
+                    Sunrise.calculate 2020 01 01
+                        69.682778<latitude> 18.942778<longitude>
+                        "W. Europe Standard Time"
+                
+                Expect.equal result Sunrise.CompleteDark
+                    "Was not complete dark in Tromso in January"
+
+        ]

--- a/tests/Bristlecone.Tests/Dendro.fs
+++ b/tests/Bristlecone.Tests/Dendro.fs
@@ -12,15 +12,12 @@ let config = Config.config
 let sunrise =
     testList
         "Sunrise calculations"
-        [
-            testCase "Complete dark during polar winter" <| fun _ ->
+        [ testCase "Complete dark during polar winter"
+          <| fun _ ->
 
-                let result =
-                    Sunrise.calculate 2020 01 01
-                        69.682778<latitude> 18.942778<longitude>
-                        "W. Europe Standard Time"
-                
-                Expect.equal result Sunrise.CompleteDark
-                    "Was not complete dark in Tromso in January"
+              let result =
+                  Sunrise.calculate 2020 01 01 69.682778<latitude> 18.942778<longitude> "W. Europe Standard Time"
 
-        ]
+              Expect.equal result Sunrise.CompleteDark "Was not complete dark in Tromso in January"
+
+          ]

--- a/tests/Bristlecone.Tests/Language.fs
+++ b/tests/Bristlecone.Tests/Language.fs
@@ -49,7 +49,7 @@ let modelExpressions =
           <| fun (x: NormalFloat) t pool env -> This |> compute x.Get t pool env = x.Get
 
           testProperty "'Time' equals the current time"
-          <| fun x (t: NormalFloat) pool env -> Time |> compute x t.Get pool env = t.Get
+          <| fun x (t: NormalFloat) pool env -> Time |> compute x (t.Get * 1.<Time.``time index``>) pool env = t.Get
 
           testProperty "A constant is purely represented"
           <| fun (c: NormalFloat) x t pool env -> Constant c.Get |> compute x t pool env = c.Get
@@ -117,7 +117,7 @@ let modelBuilder =
         [
 
           testProperty "Does not compile when more than one likelihood function"
-          <| fun (likelihoodFns: ModelSystem.LikelihoodFn list) ->
+          <| fun (likelihoodFns: ModelSystem.LikelihoodFn<float> list) ->
               let f () =
                   likelihoodFns
                   |> Seq.fold (fun mb l -> mb |> Model.useLikelihoodFunction l) Model.empty
@@ -168,7 +168,7 @@ let modelBuilder =
                       mb |> Model.compile |> ignore
 
           testPropertyWithConfig Config.config "Compiles whether measures are present or not"
-          <| fun likelihood (measures: CodedMap<ModelSystem.MeasureEquation>) ->
+          <| fun likelihood (measures: CodedMap<ModelSystem.Measurement<float>>) ->
               if measures.Keys |> Seq.hasDuplicates then
                   ()
               else
@@ -186,7 +186,7 @@ let modelBuilder =
           <| fun
                  likelihood
                  (eqs: ShortCode.ShortCode list)
-                 (measures: (ShortCode.ShortCode * ModelSystem.MeasureEquation) list) ->
+                 (measures: (ShortCode.ShortCode * ModelSystem.Measurement<float>) list) ->
               if eqs.IsEmpty then
                   ()
               else

--- a/tests/Bristlecone.Tests/Time.fs
+++ b/tests/Bristlecone.Tests/Time.fs
@@ -164,6 +164,14 @@ let oldDateTimeSeriesTests =
         "Time series (old dates)"
         [
 
+          testPropertyWithConfig config "Observation data from time-series matches input data sequence"
+          <| fun startDate (data: NormalFloat list) years ->
+              if data.Length >= 2 then
+                let data = data |> List.map(fun d -> d.Get)
+                let ts = TimeSeries.fromSeq DateMode.radiocarbonDateMode startDate (Resolution.FixedTemporalResolution.Years years) data
+                let obs = ts |> TimeSeries.toObservations
+                Expect.sequenceEqual (obs |> Seq.map fst) data "Data were different after being in time-series"
+
           testPropertyWithConfig config "BP dates are ordered oldest to youngest"
           <| fun (data: TimeSeries.Observation<float, int<``BP (radiocarbon)``>> list) ->
               let radiocarbonDates =
@@ -187,13 +195,13 @@ let oldDateTimeSeriesTests =
                 match resolution with
                 | Resolution.Months m when m.Value >= 12<month> -> test ()
                 | Resolution.Days d when d.Value >= 365<day> -> test ()
-                | Resolution.CustomEpoch e when e > 0<``BP (radiocarbon)``> -> test ()
                 | Resolution.Years _ -> test ()
                 | _ ->
                     Expect.throws (fun _ -> test () |> ignore) "Should have thrown with lower than annual resolution"
                 
 
           ]
+
 
 module TemporalIndex =
 

--- a/tests/Bristlecone.Tests/Time.fs
+++ b/tests/Bristlecone.Tests/Time.fs
@@ -167,10 +167,17 @@ let oldDateTimeSeriesTests =
           testPropertyWithConfig config "Observation data from time-series matches input data sequence"
           <| fun startDate (data: NormalFloat list) years ->
               if data.Length >= 2 then
-                let data = data |> List.map(fun d -> d.Get)
-                let ts = TimeSeries.fromSeq DateMode.radiocarbonDateMode startDate (Resolution.FixedTemporalResolution.Years years) data
-                let obs = ts |> TimeSeries.toObservations
-                Expect.sequenceEqual (obs |> Seq.map fst) data "Data were different after being in time-series"
+                  let data = data |> List.map (fun d -> d.Get)
+
+                  let ts =
+                      TimeSeries.fromSeq
+                          DateMode.radiocarbonDateMode
+                          startDate
+                          (Resolution.FixedTemporalResolution.Years years)
+                          data
+
+                  let obs = ts |> TimeSeries.toObservations
+                  Expect.sequenceEqual (obs |> Seq.map fst) data "Data were different after being in time-series"
 
           testPropertyWithConfig config "BP dates are ordered oldest to youngest"
           <| fun (data: TimeSeries.Observation<float, int<``BP (radiocarbon)``>> list) ->
@@ -187,18 +194,21 @@ let oldDateTimeSeriesTests =
                   Expect.sequenceEqual ts.Values orderedInTime "BP Dates were not ordered with largest BP values first"
 
           testPropertyWithConfig config "Only works when resolution is greater than or equal to annual"
-            <| fun startDate (data: float list) resolution ->                
-                let test () =
-                    let ts = TimeSeries.fromSeq DateMode.radiocarbonDateMode startDate resolution data
-                    Expect.equal (TimeSeries.resolution ts) (Resolution.Fixed resolution)
-                        "Resolution of resultant time-series did not match input resolution"
-                match resolution with
-                | Resolution.Months m when m.Value >= 12<month> -> test ()
-                | Resolution.Days d when d.Value >= 365<day> -> test ()
-                | Resolution.Years _ -> test ()
-                | _ ->
-                    Expect.throws (fun _ -> test () |> ignore) "Should have thrown with lower than annual resolution"
-                
+          <| fun startDate (data: float list) resolution ->
+              let test () =
+                  let ts = TimeSeries.fromSeq DateMode.radiocarbonDateMode startDate resolution data
+
+                  Expect.equal
+                      (TimeSeries.resolution ts)
+                      (Resolution.Fixed resolution)
+                      "Resolution of resultant time-series did not match input resolution"
+
+              match resolution with
+              | Resolution.Months m when m.Value >= 12<month> -> test ()
+              | Resolution.Days d when d.Value >= 365<day> -> test ()
+              | Resolution.Years _ -> test ()
+              | _ -> Expect.throws (fun _ -> test () |> ignore) "Should have thrown with lower than annual resolution"
+
 
           ]
 


### PR DESCRIPTION
For time-series, time-frame and time-index, allows using a pre-built dating mode or a custom dating mode rather than being constrained to the .NET DateTime type.

Includes:
* Uncalibrated radiocarbon dates
* Annually-resolved data
* DateTime (as before).