### PR TITLE
dotnet tools update

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "fake-cli": {
-      "version": "6.0.0",
+      "version": "6.1.3",
       "commands": [
         "fake"
       ]
     },
     "paket": {
-      "version": "8.0.3",
+      "version": "9.0.2",
       "commands": [
         "paket"
       ]


### PR DESCRIPTION
I can see there is some other branch where there is some work to use .NET 8.0
But the fake-cli 6.1.3 actually supports .NET 8.0 so you don't even have to get rid of that.
