### PR TITLE
Fix documentation deployment

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -100,8 +100,8 @@ Target.create "CheckFormat" (fun _ ->
 // Build library & test project
 
 Target.create "Build" (fun _ ->
-    Trace.log " --- Building the app --- "
-    Fake.DotNet.DotNet.build id ("bristlecone.sln"))
+    Trace.log " --- Building the library --- "
+    Fake.DotNet.DotNet.build id "bristlecone.sln")
 
 // --------------------------------------------------------------------------------------
 // Run the unit tests using test runner & kill test runner when complete
@@ -190,7 +190,10 @@ Target.create "DocsMeta" (fun _ ->
 
 Target.create "GenerateDocs" (fun _ ->
     Fake.IO.Shell.cleanDir ".fsdocs"
-    DotNet.exec id "fsdocs" "build --clean --eval --strict" |> ignore)
+    let result = DotNet.exec id "fsdocs" "build --clean --eval --strict"
+    if result.ExitCode <> 0 then
+        failwith "Document build failed" )
+
 
 // --------------------------------------------------------------------------------------
 // Run all targets by default. Invoke 'build <Target>' to override

--- a/tests/Bristlecone.Tests/Bristlecone.Tests.fsproj
+++ b/tests/Bristlecone.Tests/Bristlecone.Tests.fsproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Bristlecone/Bristlecone.fsproj" />
     <ProjectReference Include="../../src/Bristlecone.Dendro/Bristlecone.Dendro.fsproj" />
+    <ProjectReference Include="../../src/Bristlecone.Charts.R/Bristlecone.Charts.R.fsproj" />
     <Compile Include="Config.fs" />
     <Compile Include="Tensors.fs" />
     <Compile Include="Time.fs" />


### PR DESCRIPTION
Docs are not deploying becuase the R Charts library is not being built correctly. Causes library to be built correctly and adds a check to ensure that docs must build to pass.